### PR TITLE
CP-605 add triggerOnAction to store

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -17,6 +17,19 @@ class Store extends Stream<Store> {
     _streamController.add(this);
   }
 
+  triggerOnAction(Stream action, [void onAction(T payload)]) {
+    if (onAction != null) {
+      action.listen((payload) {
+        onAction(payload);
+        trigger();
+      });
+    } else {
+      action.listen((_) {
+        trigger();
+      });
+    }
+  }
+
   StreamSubscription<Store> listen(void onData(Store event), { Function onError, void onDone(), bool cancelOnError}) {
     return _stream.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -48,5 +48,35 @@ void main() {
       return completer.future;
     });
 
+    test('should trigger in response to an action', () {
+      Action _action = new Action();
+      store.triggerOnAction(_action);
+      expectAsync(store.listen)((payload) {
+        expect(payload, equals(store));
+      });
+      _action.dispatch();
+    });
+
+    test('should execute a given method and then trigger in response to an action', () {
+      Action _action = new Action();
+      num counter = 0;
+      store.triggerOnAction(_action, (_) => counter++);
+      expectAsync(store.listen)((payload) {
+        expect(payload, equals(store));
+        expect(counter, equals(1));
+      });
+      _action.dispatch();
+    });
+
+    test('should execute a given method and then trigger in response to an action with payload', () {
+      Action<num> _action = new Action<num>();
+      num counter = 0;
+      store.triggerOnAction(_action, (payload) => counter = payload);
+      expectAsync(store.listen)((payload) {
+        expect(payload, equals(store));
+        expect(counter, equals(17));
+      });
+      _action.dispatch(17);
+    });
   });
 }


### PR DESCRIPTION
## Issue
- it was annoying to have to manually `trigger()` all over the place in stores when responding to actions, so I added a `triggerOnAction` method that supports:
  - trigger in response to an action dispatch
  - execute a basic method / callback after the action dispatch, followed by a trigger
  - execute a method with the action payload after the action dispatch, followed by a trigger
  - (see test cases for sample code)
## Changes

**Source:**
- added `triggerOnAction` method

**Tests:**
- added 3 test cases
## Areas of Regression
- none - all added functionality
## Testing
- smithy covers it
## Code Review

@maxwellpeterson-wf
@evanweible-wf
@jayudey-wf 
