### PR TITLE
CP-773 Store no longer extends Stream

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:w_flux/src/action.dart';
 
-class Store extends Stream<Store> {
+class Store {
   StreamController<Store> _streamController;
   Stream<Store> _stream;
 

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -18,26 +18,11 @@ void main() {
       store = new Store();
     });
 
-    test('should inherit from Stream', () {
-      expect(store is Stream, isTrue);
-    });
-
     test('should trigger with itself as the payload', () {
       store.listen(expectAsync((payload) {
         expect(payload, equals(store));
       }));
       store.trigger();
-    });
-
-    test('should support other stream methods', () {
-      // The point of this test is to exercise the `where` method which is made available
-      // on a store by extending stream and overriding `listen`
-      ExtendingStore _store = new ExtendingStore();
-      Stream<Store> filteredStream = _store.where((payload) => payload.name == 'Max Peterson');
-      filteredStream.listen(expectAsync((ExtendingStore payload) {
-        expect(payload.name, equals('Max Peterson'));
-      }));
-      _store.trigger();
     });
 
     test('should support stream transforms', () {


### PR DESCRIPTION
## Issue

Extending stream pollutes the `Store` api without providing much benefit. For simplicity sake we decided to remove the extension and be explicit with the methods we provide on a `Store`.
## Changes

**Source:**
- Store no longer extends Stream

**Tests:**
- Remove tests that ensure Store extends Stream.
## Areas of Regression
- Anyone using Stream methods on a Store instance, like `.where(...)`. **This constitutes a breaking change.**
## Testing
- Passing CI

@trentgrover-wf 
@evanweible-wf 
@dustinlessard-wf 
FYI @jayudey-wf
