### PR TITLE
CP-783 Add default getStoreHandlers implementation to FluxComponent.

### DIFF
--- a/lib/src/component.dart
+++ b/lib/src/component.dart
@@ -13,8 +13,7 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
   List<StreamSubscription> _subscriptions = [];
 
   componentWillMount() {
-    Map<Store, Function> handlers =
-        new Map.fromIterable(redrawOn(), value: (_) => (_) => redraw())
+    Map<Store, Function> handlers = new Map.fromIterable(redrawOn(), value: (_) => (_) => redraw())
       ..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
       StreamSubscription subscription = store.listen(handler);


### PR DESCRIPTION
## Problem

It appears that a simple implementation will suffice in many real-world situations, just redraw the component.
## Solution

Consider making that implementation the default. Consumers can still override if they need more complex behavior. This would eliminate a little bit of boilerplate.
## Regressions

None known.
## Tests

None added since there are no existing tests for the `FluxComponent` class and the implementation is trivially correct (now watch it be wrong).
## QA / +10 Instructions

Tests should pass.
