### PR TITLE
CP-784 Rename stores to store for semantic reasons

### DIFF
--- a/lib/src/component.dart
+++ b/lib/src/component.dart
@@ -8,7 +8,7 @@ import './store.dart';
 
 abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
   ActionsT get actions => this.props['actions'];
-  StoresT get stores => this.props['stores'];
+  StoresT get store => this.props['store'];
 
   List<StreamSubscription> _subscriptions = [];
 
@@ -30,8 +30,8 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
   }
 
   List<Store> redrawOn() {
-    if (stores is Store) {
-      return [stores];
+    if (store is Store) {
+      return [store];
     } else {
       return [];
     }


### PR DESCRIPTION
## Issue

Discussion here: https://github.com/timmccall-wf/truss/pull/22#discussion_r35394689
## Changes

**Source:**
- Change FluxComponent's `stores` getter to `store`

**Tests:**
- No FluxComponent tests yet
## Areas of Regression
- This is a breaking change for the FluxComponent
  - Consumers should replace occurrences of `stores` with `store`
## Testing
- CI passes

@trentgrover-wf 
@evanweible-wf 
@timmccall-wf 
FYI @jayudey-wf
