### PR TITLE
CP-854 Fix image link in README, w_flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ w_flux
 
 ## Overview
 
-![flux-diagram](https://raw.githubusercontent.com/Workiva/w_flux/images/images/flux_diagram.png?token=ADmmnoHGdNH__FUB639OtQuv9F_v3-b7ks5V04RnwA%3D%3D)
+![flux-diagram](https://github.com/Workiva/w_flux/blob/images/images/flux_diagram.png)
 
 `w_flux` implements a uni-directional data flow pattern comprised of `Actions`, `Stores`, and `FluxComponents`.
 


### PR DESCRIPTION
## Issue

The image link in the README was broken
## Changes

**Source:**
- Update link to image
## Testing
- None, doc-only change

@trentgrover-wf 
@evanweible-wf 
@dustinlessard-wf 
FYI @jayudey-wf
