### PR TITLE
CP-937 Setup Travis CI and codecov.io reporting, w_flux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 
 # dart
+.packages
 .pub
 packages
 pubspec.lock
@@ -9,5 +10,4 @@ pubspec.lock
 dartdoc-viewer/
 
 # coverage
-lcov_coverage.lcov
-lcov_report/
+/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: dart
+dart:
+  - stable
+script:
+  - pub run dart_dev format --check
+  - pub run dart_dev analyze
+  - pub run dart_dev test
+  - pub run dart_dev coverage --no-html
+  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ homepage: https://github.com/Workiva/w_flux
 dependencies:
   react: ">=0.5.0 <0.8.0"
 dev_dependencies:
-  dart_dev:
-    git: git@github.com:Workiva/dart_dev.git
+  coverage: "^0.7.2"
+  dart_dev: "^1.0.0"
   dart_style: "^0.2.0"
   test: "^0.12.3+5"
   rate_limit: 0.1.0

--- a/smithy.yml
+++ b/smithy.yml
@@ -1,9 +1,0 @@
-project: node
-language: javascript
-
-runner_image: docker.webfilings.org/devops/smithy-runner-dart1.11.0:3.2.0
-
-script:
-  - pub run dart_dev test
-  - pub run dart_dev format --check 
-  - pub run dart_dev analyze


### PR DESCRIPTION
## Issue
#27 Travis CI
#28 Codecov.io
Dart 1.12 introduces a new `.packages` file that should be ignored

## Changes
- Updated dart_dev dep to use the pub version
- Removed `smithy.yml`
- Submitted ticket to have smithy turned off for this repo: https://jira.atl.workiva.net/secure/Dashboard.jspa
- Added `travis.yml` to run..
  - static analysis
  - dart formatter check
  - tests
  - coverage
  - coverage reporting
- Added `.packages` to gitignore

## Areas of Regression
- CI builds

## Testing
- Travis CI passes
- Coverage is reported to codecov.io and codecov.io checks pass
- Ignore failing smithy checks

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf