### PR TITLE
CP-940 Update readmes to use/reference dart_dev, w_flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ w_flux
   - [**FluxComponent**](#fluxcomponent)
 - [**Examples**](#examples)
 - [**External Consumption**](#external-consumption)
+- [**Development**](#development)
 
 ---
 
@@ -242,3 +243,12 @@ normal operation without inadvertently exposing them externally.
 
 [w_module](https://github.com/Workiva/w_module) is a Dart library that defines a standard code module API that can be
 used seamlessly with `w_flux` internals to satisfy the above recommendations (complete with examples).
+
+---
+
+## Development
+
+This project leverages [the dart_dev package](https://github.com/Workiva/dart_dev)
+for most of its tooling needs, including static analysis, code formatting,
+running tests, collecting coverage, and serving examples. Check out the dart_dev
+readme for more information.

--- a/example/README.md
+++ b/example/README.md
@@ -3,5 +3,5 @@ w_flux Examples
 
 To run the examples, open the root of this repository in a command-line terminal.
 
-1. `tool/examples.sh`
+1. `pub run dart_dev examples`
 2. Open Chromium/Dartium to `http://localhost:8080`


### PR DESCRIPTION
## Issue
- #32 
- Missing a "development" section in the readme

## Changes
- Update example readme to use a `dart_dev` command to serve examples
- Update main readme to include a "development" section that references dart_dev

> **Docs only change.**

## Areas of Regression
- Instructions for serving examples

## Testing
- Following instructions in /example/README.md should successfully serve the examples

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 