### PR TITLE
CP-1017 Fix usage of expect-async in action tests.

### DIFF
--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -30,25 +30,25 @@ void main() {
     test('should support dispatch without a payload', () {
       Action _action = new Action();
 
-      expectAsync(_action.listen)((payload) {
+      _action.listen(expectAsync((payload) {
         expect(payload, equals(null));
-      });
+      }));
 
       _action();
     });
 
     test('should support dispatch with a payload', () {
-      expectAsync(action.listen)((payload) {
+      action.listen(expectAsync((payload) {
         expect(payload, equals('990 guerrero'));
-      });
+      }));
 
       action('990 guerrero');
     });
 
     test('should dispatch by default when called', () {
-      expectAsync(action.listen)((payload) {
+      action.listen(expectAsync((payload) {
         expect(payload, equals('990 guerrero'));
-      });
+      }));
 
       action('990 guerrero');
     });


### PR DESCRIPTION
## Issue
`expectAsync` is being used incorrectly in our action tests. The current usage correctly catches incorrect payloads, but does not fail when the actions are not called.

## Changes
**Tests:**
- Updated `expectAsync` usage to wrap the `action.listen` callback.

## Areas of Regression
- n/a

## Testing
- CI Passes.
- Commenting out lines 37, 45, and 53 in `test/action_test.dart` should cause those respective tests to timeout

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 