### PR TITLE
CP-1055 Allow react 0.8.0 in dependency range, w_flux

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_flux
 dependencies:
-  react: ">=0.5.0 <0.8.0"
+  react: ">=0.5.0 <0.9.0"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"


### PR DESCRIPTION
## Issue
Fixes #39 

## Changes
**Source:**
- Update `react` dependency range to include 0.8.x

## Areas of Regression
- None

## Testing
- CI passes

@trentgrover-wf 
@evanweible-wf 
@dustinlessard-wf 
FYI @jayudey-wf