### PR TITLE
CP-1152 Add clearListeners method to Action

### DIFF
--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -134,6 +134,20 @@ void main() {
         await action();
         expect(listened, isFalse);
       });
+
+      test('should stop listening when listeners are cleared', () async {
+        var action = new Action();
+        var listened = false;
+        action.listen((_) => listened = true);
+
+        await action();
+        expect(listened, isTrue);
+
+        listened = false;
+        action.clearListeners();
+        await action();
+        expect(listened, isFalse);
+      });
     });
 
     group('benchmarks', () {


### PR DESCRIPTION
## Issue
It would be nice to be able to have a way to easily cancel all Action subscriptions in the teardown of a unit test or some module.

This PR allows consumers to clear all listeners of an Action with a new `clearListeners` method.

## Changes
**Source:**
- Add `clearListeners` method to `Action`.

**Tests:**
- Add unit test to ensure `.clearListeners()` works as expected

## Areas of Regression
- None. New functionality only.

## Testing
- CI passes
- Unit test properly covers new functionality

## Code Review
@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf