### PR TITLE
REF-278 Add batched redraws and basic tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: dart
 dart:
   - stable
+with_content_shell: true
+before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze

--- a/lib/src/component.dart
+++ b/lib/src/component.dart
@@ -18,12 +18,14 @@ import 'dart:async';
 
 import 'package:react/react.dart' as react;
 
+import './mixins/batched_redraws.dart';
 import './store.dart';
 
 /// FluxComponents are responsible for rendering application views and turning
 /// user interactions and events into [Action]s. FluxComponents can use data
 /// from one or many [Store] instances to define the resulting component.
-abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
+abstract class FluxComponent<ActionsT, StoresT> extends react.Component
+    with BatchedRedraws {
   /// The class instance defined by [ActionsT] that holds all [Action]s that
   /// this component needs access to.
   ///

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -1,0 +1,43 @@
+library w_flux.mixins.scheduled_redraws;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:react/react.dart' as react;
+
+class _RedrawScheduler implements Function {
+  Set<react.Component> _components = new Set();
+
+  void call(react.Component component) {
+    if (_components.isEmpty) {
+      _tick();
+    }
+    _components.add(component);
+  }
+
+  Future _tick() async {
+    await window.animationFrame;
+    _components
+      ..forEach((c) {
+        c.setState({});
+      })
+      ..clear();
+  }
+}
+
+_RedrawScheduler _scheduleRedraw = new _RedrawScheduler();
+
+/// A mixin that overrides the [Component.redraw] method of a React
+/// [Component] (including a [FluxComponent] and prevents the component
+/// from being redrawn more than once per animation frame.
+///
+/// Example:
+///
+///     class MyComponent extends FluxComponent<Actions, Store>
+///         with BatchedRedraws {
+///       render() {...}
+///     }
+///
+class BatchedRedraws {
+  void redraw() => _scheduleRedraw(this as react.Component);
+}

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -1,4 +1,4 @@
-library w_flux.mixins.scheduled_redraws;
+library w_flux.mixins.batched_redraws;
 
 import 'dart:async';
 import 'dart:html';
@@ -33,7 +33,7 @@ _RedrawScheduler _scheduleRedraw = new _RedrawScheduler();
 ///
 /// Example:
 ///
-///     class MyComponent extends FluxComponent<Actions, Store>
+///     class MyComponent extends react.Component
 ///         with BatchedRedraws {
 ///       render() {...}
 ///     }

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -28,7 +28,7 @@ class _RedrawScheduler implements Function {
 _RedrawScheduler _scheduleRedraw = new _RedrawScheduler();
 
 /// A mixin that overrides the [Component.redraw] method of a React
-/// [Component] (including a [FluxComponent] and prevents the component
+/// [Component] (including a [FluxComponent]) and prevents the component
 /// from being redrawn more than once per animation frame.
 ///
 /// Example:

--- a/lib/w_flux.dart
+++ b/lib/w_flux.dart
@@ -24,3 +24,4 @@ library w_flux;
 export 'src/action.dart';
 export 'src/component.dart';
 export 'src/store.dart';
+export 'src/mixins/batched_redraws.dart';

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@TestOn('vm')
 library w_flux.test.action_test;
 
 import 'dart:async';
 
-import 'package:w_flux/w_flux.dart';
+import 'package:w_flux/src/action.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@TestOn('browser')
 library w_flux.test.component_test;
 
 import 'dart:async';

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -52,8 +52,8 @@ void main() {
       expect(component.renderCount, equals(1));
     });
 
-    test('should not redraw the component more than once per animation'
-        'frame', () async {
+    test('should not redraw the component more than once per animation frame',
+        () async {
       component.redraw();
       component.redraw();
       await nextTick();

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -1,0 +1,63 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+library w_flux.test.batched_redraws_test;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:react/react.dart' as react;
+
+import 'package:w_flux/w_flux.dart';
+import 'package:test/test.dart';
+
+class _TestComponent extends react.Component with BatchedRedraws {
+  int renderCount = 0;
+
+  dynamic render() => '';
+
+  void setState(_) {
+    renderCount++;
+  }
+}
+
+void main() {
+  Future nextTick() async {
+    await window.animationFrame;
+    await window.animationFrame;
+  }
+
+  group('ScheduledRedraws', () {
+    _TestComponent component;
+
+    setUp(() {
+      component = new _TestComponent();
+    });
+
+    test('should redraw the component when redraw() is called', () async {
+      component.redraw();
+      await nextTick();
+      expect(component.renderCount, equals(1));
+    });
+
+    test('should not redraw the component more than once per animation'
+        'frame', () async {
+      component.redraw();
+      component.redraw();
+      await nextTick();
+      expect(component.renderCount, equals(1));
+    });
+  });
+}

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@TestOn('vm')
 library w_flux.test.store_test;
 
 import 'dart:async';
 
-import 'package:w_flux/w_flux.dart';
+import 'package:w_flux/src/action.dart';
+import 'package:w_flux/src/store.dart';
 import 'package:rate_limit/rate_limit.dart';
 import 'package:test/test.dart';
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -24,6 +24,7 @@ main(List<String> args) async {
   config.analyze.entryPoints = dirs;
   config.copyLicense.directories = dirs;
   config.format.directories = dirs;
+  config.test.platforms = ['vm', 'content-shell'];
 
   await dev(args);
 }


### PR DESCRIPTION
## Problem

`FluxComponent` instances aren't very smart about how they redraw and will happily attempt to redraw multiple times per animation frame. This results in some pretty dramatic performance problems and forces manual tuning.

## Solution

We have seen some nice performance improvements by making them a little smarter and we thought this would make a nice addition to w_flux itself. Basically, we override the `redraw()` method and batch redraws across all components.

The first time a component asks for a redraw a countdown is started, subsequent redraw requests from that component will be ignored. Requests from other components between the time the countdown is started and the time the countdown expires (on the next animation frame) will be added and handled when the countdown expires. We then call `setState({})` on each component that requested a redraw while we were waiting for an animation frame.

This PR makes a couple small changes to w_flux itself. First, we need the `window` object, so I had to let the tests run on the content shell. I modified the other test files to run on the most appropriate platform. Second, `FluxComponent` has redraw batching built-in, so all children will get it as well. We couldn't think of any situations where this would cause a problem since (hopefully) no one (else) overrides `redraw()`. Finally, we export the mixin we use to add the batched rendering so that it can be used on plain old React components if someone finds that useful.

## Tests

Added and/or updated.

## QA / +10

1. Checkout the branch.
2. Update dependencies.
3. Unit tests should pass.
4. No regressions.

## FYI

@trentgrover-wf @todbachman-wf 