### PR TITLE
CP-1168 fix strong mode analysis errors / warnings, w_flux

### DIFF
--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -77,6 +77,11 @@ class Action<T> implements Function {
     _listeners.add(onData);
     return new ActionSubscription(() => _listeners.remove(onData));
   }
+
+  /// Actions are only deemed equivalent if they are the exact same Object
+  bool operator ==(Object other) {
+    return identical(this, other);
+  }
 }
 
 /// A subscription used to cancel registered listeners to an [Action].

--- a/lib/src/component.dart
+++ b/lib/src/component.dart
@@ -30,7 +30,7 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
   /// There is no strict rule on the [ActionsT] type. Depending on application
   /// structure, there may be [Action]s available directly on this object, or
   /// this object may represent a hierarchy of actions.
-  ActionsT get actions => this.props['actions'];
+  ActionsT get actions => this.props['actions'] as ActionsT;
 
   /// The class instance defined by [StoresT]. This object should either be an
   /// instance of [Store] or should provide access to one or more [Store]s.
@@ -48,7 +48,7 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
   /// [StoresT] should be a class that provides access to these multiple stores.
   /// Then, you can explicitly select the [Store] instances that should be
   /// listened to by overriding [redrawOn].
-  StoresT get store => this.props['store'];
+  StoresT get store => this.props['store'] as StoresT;
 
   /// List of store subscriptions created when the component mounts. These
   /// subscriptions are canceled when the component is unmounted.
@@ -59,8 +59,9 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
     // have their triggers mapped directly to this components redraw function.
     // Stores included in the `getStoreHandlers()` result will be listened to
     // and wired up to their respective handlers.
-    Map<Store, Function> handlers = new Map.fromIterable(redrawOn(),
-        value: (_) => (_) => redraw())..addAll(getStoreHandlers());
+    Map<Store, Function> handlers =
+        (new Map.fromIterable(redrawOn(), value: (_) => (_) => redraw())
+            as Map<Store, Function>)..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
       StreamSubscription subscription = store.listen(handler);
       _subscriptions.add(subscription);
@@ -92,7 +93,7 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
   ///     redrawOn() => [store.tasks, store.users];
   List<Store> redrawOn() {
     if (store is Store) {
-      return [store];
+      return [store as Store];
     } else {
       return [];
     }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -51,13 +51,14 @@ class Store {
   /// As an example, [transformer] could be used to throttle the number of
   /// triggers this [Store] emits for state that may update extremely frequently
   /// (like scroll position).
-  Store({StreamTransformer transformer}) {
+  Store({StreamTransformer<dynamic, dynamic> transformer}) {
     _streamController = new StreamController<Store>();
 
     // apply a transform to the stream if supplied
     if (transformer != null) {
-      _stream =
-          _streamController.stream.transform(transformer).asBroadcastStream();
+      _stream = _streamController.stream
+          .transform(transformer as StreamTransformer<Store, dynamic>)
+          .asBroadcastStream() as Stream<Store>;
     } else {
       _stream = _streamController.stream.asBroadcastStream();
     }

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -27,28 +27,35 @@ void main() {
       action = new Action<String>();
     });
 
+    test('should only be equivalent to itself', () {
+      Action _action = new Action();
+      Action _action2 = new Action();
+      expect(_action == _action, isTrue);
+      expect(_action == _action2, isFalse);
+    });
+
     test('should support dispatch without a payload', () {
       Action _action = new Action();
 
-      _action.listen(expectAsync((payload) {
-        expect(payload, equals(null));
-      }));
+      _action.listen((payload) => expectAsync((payload) {
+            expect(payload, equals(null));
+          }));
 
       _action();
     });
 
     test('should support dispatch with a payload', () {
-      action.listen(expectAsync((payload) {
-        expect(payload, equals('990 guerrero'));
-      }));
+      action.listen((String payload) => expectAsync((payload) {
+            expect(payload, equals('990 guerrero'));
+          }));
 
       action('990 guerrero');
     });
 
     test('should dispatch by default when called', () {
-      action.listen(expectAsync((payload) {
-        expect(payload, equals('990 guerrero'));
-      }));
+      action.listen((String payload) => expectAsync((payload) {
+            expect(payload, equals('990 guerrero'));
+          }));
 
       action('990 guerrero');
     });

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -29,9 +29,9 @@ void main() {
     });
 
     test('should trigger with itself as the payload', () {
-      store.listen(expectAsync((payload) {
-        expect(payload, equals(store));
-      }));
+      store.listen((Store payload) => expectAsync((payload) {
+            expect(payload, equals(store));
+          }));
       store.trigger();
     });
 
@@ -42,9 +42,9 @@ void main() {
       // all others that occurred within the throttled duration)
       store = new Store(
           transformer: new Throttler(const Duration(milliseconds: 30)));
-      store.listen(expectAsync((payload) {
-        expect(payload, equals(store));
-      }, count: 2));
+      store.listen((Store payload) => expectAsync((payload) {
+            expect(payload, equals(store));
+          }, count: 2));
 
       store.trigger();
       store.trigger();
@@ -56,9 +56,9 @@ void main() {
     test('should trigger in response to an action', () {
       Action _action = new Action();
       store.triggerOnAction(_action);
-      store.listen(expectAsync((payload) {
-        expect(payload, equals(store));
-      }));
+      store.listen((Store payload) => expectAsync((payload) {
+            expect(payload, equals(store));
+          }));
       _action();
     });
 
@@ -71,10 +71,10 @@ void main() {
         methodCalled = true;
       }
       store.triggerOnAction(_action, syncCallback);
-      store.listen(expectAsync((payload) {
-        expect(payload, equals(store));
-        expect(methodCalled, equals(true));
-      }));
+      store.listen((Store payload) => expectAsync((payload) {
+            expect(payload, equals(store));
+            expect(methodCalled, equals(true));
+          }));
       _action();
     });
 
@@ -88,10 +88,10 @@ void main() {
         afterTimer = true;
       }
       store.triggerOnAction(_action, asyncCallback);
-      store.listen(expectAsync((payload) {
-        expect(payload, equals(store));
-        expect(afterTimer, equals(true));
-      }));
+      store.listen((Store payload) => expectAsync((payload) {
+            expect(payload, equals(store));
+            expect(afterTimer, equals(true));
+          }));
       _action();
     });
 
@@ -101,10 +101,10 @@ void main() {
       Action<num> _action = new Action<num>();
       num counter = 0;
       store.triggerOnAction(_action, (payload) => counter = payload);
-      store.listen(expectAsync((payload) {
-        expect(payload, equals(store));
-        expect(counter, equals(17));
-      }));
+      store.listen((Store payload) => expectAsync((payload) {
+            expect(payload, equals(store));
+            expect(counter, equals(17));
+          }));
       _action(17);
     });
   });


### PR DESCRIPTION
## Issue
- ran `dartanalyzer --strong lib/w_flux.dart` and fixed the output results:
```
Analyzing [lib/w_flux.dart]...
[error] Type check failed: [store] (List<dynamic>) is not of type List<Store> because store cannot be typed as Store (/Volumes/CASE/code/w_flux/lib/src/component.dart, line 95, col 14)
[warning] Missing concrete implementation of 'Function.==' (/Volumes/CASE/code/w_flux/lib/src/action.dart, line 44, col 7)
[warning] this.props['actions'] (dynamic) will need runtime check to cast to type ActionsT (/Volumes/CASE/code/w_flux/lib/src/component.dart, line 33, col 27)
[warning] this.props['store'] (dynamic) will need runtime check to cast to type StoresT (/Volumes/CASE/code/w_flux/lib/src/component.dart, line 51, col 24)
[warning] new Map.fromIterable(redrawOn(), value: (_) => (_) => redraw())..addAll(getStoreHandlers()) (Map<dynamic, dynamic>) will need runtime check to cast to type Map<Store, Function> (/Volumes/CASE/code/w_flux/lib/src/component.dart, line 62, col 37)
[warning] _streamController.stream.transform(transformer).asBroadcastStream() (Stream<dynamic>) will need runtime check to cast to type Stream<Store> (/Volumes/CASE/code/w_flux/lib/src/store.dart, line 60, col 11)
[warning] transformer (StreamTransformer<dynamic, dynamic>) will need runtime check to cast to type StreamTransformer<Store, dynamic> (/Volumes/CASE/code/w_flux/lib/src/store.dart, line 60, col 46)
1 error and 6 warnings found.
```
- In theory, there are probably benefits to this because it will eliminate some run time data type checks, but I didn't see any immediate difference.

## Changes
**Source:**
- mostly adding some explicit type casting to things

**Tests:**
- no change needed

## Code Review
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf 
@jayudey-wf