### PR TITLE
Add null checking before store subscription

### DIFF
--- a/lib/src/component.dart
+++ b/lib/src/component.dart
@@ -62,8 +62,10 @@ abstract class FluxComponent<ActionsT, StoresT> extends react.Component {
     Map<Store, Function> handlers = new Map.fromIterable(redrawOn(),
         value: (_) => (_) => redraw())..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
-      StreamSubscription subscription = store.listen(handler);
-      _subscriptions.add(subscription);
+      if (store != null) {
+        StreamSubscription subscription = store.listen(handler);
+        _subscriptions.add(subscription);
+      }
     });
   }
 

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -84,6 +84,19 @@ void main() {
       expect(component.numberOfRedraws, 2);
     });
 
+    test('should avoid null errors when a store returned from redrawOn is null', () async {
+      TestRedrawOnComponent component = new TestRedrawOnComponent();
+      TestStores stores = new TestStores();
+      stores.store1 = null;
+      component.props = {'store': stores};
+      // This should not through even though store1 is null
+      component.componentWillMount();
+
+      stores.store2.trigger();
+      await nextTick();
+      expect(component.numberOfRedraws, 1);
+    });
+
     test('should prefer a handler specified in getStoreHandlers over redrawOn',
         () async {
       TestHandlerPrecedence component = new TestHandlerPrecedence();


### PR DESCRIPTION
## Issue
A consumer of `FluxComponent` may override `redrawOn()` to return multiple stores. If any of those stores are null (perhaps they haven't been initialized yet), subscribing to the store will throw a null reference error in w_flux boilerplate.

## Changes
**Source:**
- Null check the store before listening to it.

**Tests:**
- Ensure boilerplate `componentWillMount` will work with null store(s).

## Areas of Regression
- FluxComponent

## Testing
- CI passes
- Unit test correctly tests issue

## Code Review
@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf