### PR TITLE
CP-1192 Store: switch to a default ctor and a transformer ctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ import 'package:w_flux/w_flux.dart';
 class ThrottledStore extends Store {
   ...
 
-  ThrottledStore(this._actions) : super(transformer: new Throttler(const Duration(milliseconds: 30))) {
+  ThrottledStore(this._actions) : super.withTransformer(new Throttler(const Duration(milliseconds: 30))) {
     ...
   }
 }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -43,25 +43,26 @@ class Store {
   Stream<Store> _stream;
 
   /// Construct a new [Store] instance.
+  Store() {
+    _streamController = new StreamController<Store>();
+    _stream = _streamController.stream.asBroadcastStream();
+  }
+
+  /// Construct a new [Store] instance with a transformer.
   ///
-  /// If a [transformer] is given, the standard behavior of the "trigger" stream
-  /// will be modified. The underlying stream will be transformed using
-  /// [transformer].
+  /// The standard behavior of the "trigger" stream will be modified. The
+  /// underlying stream will be transformed using [transformer].
   ///
   /// As an example, [transformer] could be used to throttle the number of
   /// triggers this [Store] emits for state that may update extremely frequently
   /// (like scroll position).
-  Store({StreamTransformer<dynamic, dynamic> transformer}) {
+  Store.withTransformer(StreamTransformer<dynamic, dynamic> transformer) {
     _streamController = new StreamController<Store>();
 
     // apply a transform to the stream if supplied
-    if (transformer != null) {
-      _stream = _streamController.stream
-          .transform(transformer as StreamTransformer<Store, dynamic>)
-          .asBroadcastStream() as Stream<Store>;
-    } else {
-      _stream = _streamController.stream.asBroadcastStream();
-    }
+    _stream = _streamController.stream
+        .transform(transformer as StreamTransformer<Store, dynamic>)
+        .asBroadcastStream() as Stream<Store>;
   }
 
   /// Trigger a "data updated" event. All registered listeners of this `Store`

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -40,8 +40,8 @@ void main() {
       // exactly 2 throttled triggers to external listeners
       // (1 for the initial trigger and 1 as the aggregate of
       // all others that occurred within the throttled duration)
-      store = new Store(
-          transformer: new Throttler(const Duration(milliseconds: 30)));
+      store = new Store.withTransformer(
+          new Throttler(const Duration(milliseconds: 30)));
       store.listen((Store payload) => expectAsync((payload) {
             expect(payload, equals(store));
           }, count: 2));


### PR DESCRIPTION
## Issue
- #48 Because the only constructor in `Store` has optional parameters, extending classes cannot mix other classes in.

## Changes
**Source:**
- Fix #48 by removing the optional `transformer` parameter from the default `Store` constructor and replacing it with a named `Store.withTransformer()` constructor. **This is a breaking change.**

**Tests:**
- Update test for transformer usage.

## Areas of Regression
- Store streams (transformed or not).

## Testing
- CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 