### PR TITLE
CP-1415 Allow use of react-dart 0.9.0, w_flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.1.0
+Support for react-dart 0.9.x (which moves to ReactJS 0.14)
+
+## 2.0.0
+Check out the detailed [release notes](//github.com/Workiva/w_flux/releases/tag/2.0.0).
+
+- Store now uses a named constructor when specifying a transformer instead of an optional
+constructor parameter
+
+## 1.1.0
+Check out the detailed [release notes](//github.com/Workiva/w_flux/releases/tag/1.1.0).
+
+- Added batched redraws
+
 ## 1.0.1
 Check out the detailed [release notes](//github.com/Workiva/w_flux/releases/tag/1.0.1).
 

--- a/example/random_color/index.html
+++ b/example/random_color/index.html
@@ -23,7 +23,7 @@ limitations under the License.
     <body>
         <div id="content-container"></div>
 
-        <script src="packages/react/react_prod.js"></script>
+        <script src="packages/react/react_with_react_dom_prod.js"></script>
         <script type="application/dart" src="random_color.dart"></script>
         <script src="packages/browser/dart.js"></script>
     </body>

--- a/example/todo_app/index.html
+++ b/example/todo_app/index.html
@@ -24,7 +24,7 @@ limitations under the License.
     <body>
         <div id="content-container"></div>
 
-        <script src="packages/react/react_prod.js"></script>
+        <script src="packages/react/react_with_react_dom_prod.js"></script>
         <script type="application/dart" src="todo_app.dart"></script>
         <script src="packages/browser/dart.js"></script>
     </body>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_flux
 dependencies:
-  react: ">=0.5.0 <0.9.0"
+  react: ">=0.5.0 <0.10.0"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -35,30 +35,39 @@ void main() {
       expect(_action == _action2, isFalse);
     });
 
-    test('should support dispatch without a payload', () {
+    test('should support dispatch without a payload', () async {
+      Completer c = new Completer();
       Action _action = new Action();
 
-      _action.listen((payload) => expectAsync((payload) {
-            expect(payload, equals(null));
-          }));
+      _action.listen((String payload) {
+        expect(payload, equals(null));
+        c.complete();
+      });
 
       _action();
+      return c.future;
     });
 
-    test('should support dispatch with a payload', () {
-      action.listen((String payload) => expectAsync((payload) {
-            expect(payload, equals('990 guerrero'));
-          }));
+    test('should support dispatch with a payload', () async {
+      Completer c = new Completer();
+      action.listen((String payload) {
+        expect(payload, equals('990 guerrero'));
+        c.complete();
+      });
 
       action('990 guerrero');
+      return c.future;
     });
 
-    test('should dispatch by default when called', () {
-      action.listen((String payload) => expectAsync((payload) {
-            expect(payload, equals('990 guerrero'));
-          }));
+    test('should dispatch by default when called', () async {
+      Completer c = new Completer();
+      action.listen((String payload) {
+        expect(payload, equals('990 guerrero'));
+        c.complete();
+      });
 
       action('990 guerrero');
+      return c.future;
     });
 
     group('dispatch', () {

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -21,11 +21,9 @@ import 'package:react/react.dart' as react;
 import 'package:test/test.dart';
 import 'package:w_flux/w_flux.dart';
 
-void main() {
-  Future nextTick() {
-    return new Future.delayed(new Duration(milliseconds: 1));
-  }
+import 'utils.dart';
 
+void main() {
   group('FluxComponent', () {
     test('should expose an actions getter', () {
       TestDefaultComponent component = new TestDefaultComponent();

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,7 @@
+library w_flux.test.utils;
+
+import 'dart:async';
+
+Future nextTick([int milliseconds = 1]) {
+  return new Future.delayed(new Duration(milliseconds: milliseconds));
+}


### PR DESCRIPTION
## Issue
react-dart 0.9.0 is available.

## Changes
**Source:**
- Update react dependency range.

**Tests:**
- Fix tests that are currently broken in master.

## Areas of Regression
- Examples

## Testing
- CI passes
- Examples function correctly

## Code Review
@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf
FYI @aaronlademann-wf 