### PR TITLE
CP-1598 Widen react-dart version range to support 1.0.0, w_flux

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_flux
 dependencies:
-  react: ">=0.5.0 <0.10.0"
+  react: ">=0.5.0 <2.0.0"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"


### PR DESCRIPTION
react-dart 1.0.0 was just released, and it is still compatible with the current version w_flux.

The `react` version range has been updated to include 1.x.x versions.

@trentgrover-wf @maxwellpeterson-wf @evanweible-wf 