### PR TITLE
CP-1432 Release w_flux 2.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.1.0
+version: 2.2.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1432

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1598  - Widen react-dart version range to support 1.0.0, w_flux  - https://github.com/Workiva/w_flux/pull/56

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.1.0...CP-1432_release_2.2.0

