### PR TITLE
CP-1600 Release w_flux 2.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.2.0
+version: 2.3.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1600

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1736  - New entry point for use on the server  - https://github.com/Workiva/w_flux/pull/58

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.2.0...CP-1600_release_2.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.2.0...2.3.0

