### PR TITLE
CP-1931 Widen react-dart version range to support 2.0.0

### DIFF
--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -18,6 +18,7 @@ import 'dart:html';
 import 'dart:math';
 
 import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
 import 'package:w_flux/w_flux.dart';
@@ -29,7 +30,7 @@ main() async {
 
   // render the component
   react_client.setClientConfiguration();
-  react.render(RandomColorComponent({'actions': actions, 'store': store}),
+  react_dom.render(RandomColorComponent({'actions': actions, 'store': store}),
       querySelector('#content-container'));
 }
 

--- a/example/todo_app/todo_app.dart
+++ b/example/todo_app/todo_app.dart
@@ -16,7 +16,7 @@ library w_flux.example.todo_app;
 
 import 'dart:html';
 
-import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
 import 'actions.dart';
@@ -30,6 +30,6 @@ main() async {
 
   // render the component
   react_client.setClientConfiguration();
-  react.render(ToDoAppComponent({'actions': actions, 'store': store}),
+  react_dom.render(ToDoAppComponent({'actions': actions, 'store': store}),
       querySelector('#content-container'));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_flux
 dependencies:
-  react: ">=0.5.0 <3.0.0"
+  react: ">=0.9.0 <3.0.0"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_flux
 dependencies:
-  react: ">=0.5.0 <2.0.0"
+  react: ">=0.5.0 <3.0.0"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"


### PR DESCRIPTION
react-dart 2.0.0 was just released, and it is still compatible with the current version w_flux.

The react version range has been updated to include 2.x.x versions.

Do not use removed API in examples.

@trentgrover-wf @maxwellpeterson-wf @evanweible-wf