### PR TITLE
CP-1753 Release w_flux 2.3.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.3.0
+version: 2.3.1
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1753

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



======= w_flux 2.3.1 items =======

 CP-1931  - Widen react-dart version range to support 2.0.0  - https://github.com/Workiva/w_flux/pull/60
======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.3.0...CP-1753_release_2.3.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.3.0...2.3.1

