### PR TITLE
CP-2381 Bump react-dart version constraint to ^3.0.0

### DIFF
--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -16,31 +16,26 @@ class _RedrawScheduler implements Function {
 
     _components[component] ??= [];
 
-    _components[component].add(callback);
+    if (callback != null) _components[component].add(callback);
   }
 
   Future _tick() async {
     await window.animationFrame;
     _components
       ..forEach((component, callbacks) {
-        var chainedCallbacks = callbacks.fold(null, _chain) ?? _noop;
+        var chainedCallbacks;
+
+        if (callbacks.isNotEmpty) {
+          chainedCallbacks = () {
+            callbacks.forEach((callback) {
+              callback();
+            });
+          };
+        }
 
         component.setState({}, chainedCallbacks);
       })
       ..clear();
-  }
-
-  void _noop() {}
-
-  Function _chain(a(), b()) {
-    if (a == null && b == null) return _noop;
-    if (a == null) return b;
-    if (b == null) return a;
-
-    return () {
-      a();
-      b();
-    };
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/w_flux
 dependencies:
-  react: ">=0.9.0 <3.0.0"
+  react: "^3.0.0"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -181,7 +181,7 @@ class TestDefaultComponent extends FluxComponent {
 
   render() => react.div({});
 
-  redraw() {
+  redraw([callback()]) {
     numberOfRedraws += 1;
   }
 }
@@ -205,7 +205,7 @@ class TestRedrawOnComponent extends FluxComponent<TestActions, TestStores> {
 
   redrawOn() => [store.store1, store.store2];
 
-  redraw() {
+  redraw([callback()]) {
     numberOfRedraws += 1;
   }
 }
@@ -224,7 +224,7 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
     numberOfHandlerCalls += 1;
   }
 
-  redraw() {
+  redraw([callback()]) {
     numberOfRedraws += 1;
   }
 }

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -181,7 +181,7 @@ class TestDefaultComponent extends FluxComponent {
 
   render() => react.div({});
 
-  redraw() {
+  redraw([callback()]) {
     numberOfRedraws += 1;
   }
 }
@@ -205,7 +205,7 @@ class TestRedrawOnComponent extends FluxComponent<TestActions, TestStores> {
 
   redrawOn() => [store.store1, store.store2];
 
-  redraw() {
+  redraw([callback()]) {
     numberOfRedraws += 1;
   }
 }
@@ -224,7 +224,7 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
     numberOfHandlerCalls += 1;
   }
 
-  redraw() {
+  redraw([callback()]) {
     numberOfRedraws += 1;
   }
 }

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -81,6 +81,7 @@ void main() {
       syncCallback(_) {
         methodCalled = true;
       }
+
       store.triggerOnAction(_action, syncCallback);
       store.listen((Store payload) => expectAsync((payload) {
             expect(payload, equals(store));
@@ -98,6 +99,7 @@ void main() {
         await new Future.delayed(new Duration(milliseconds: 30));
         afterTimer = true;
       }
+
       store.triggerOnAction(_action, asyncCallback);
       store.listen((Store payload) => expectAsync((payload) {
             expect(payload, equals(store));


### PR DESCRIPTION
react-dart 3.0.0 was just released, it includes the addition of setState/redraw callbacks.

`BatchedRedrawMixin` and `_RedrawScheduler ` needed to be updated to support this.

Now `_RedrawScheduler` chains all callbacks passed to `redraw` and passes the chained function to `setState`.

This will need to be a major release due to the API in `BatchedRedrawMixin` updating.

@trentgrover-wf @maxwellpeterson-wf @evanweible-wf @greglittlefield-wf @georgelesica-wf 