### PR TITLE
CP-2036 Release w_flux 2.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.3.1
+version: 2.4.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-2036

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= w_flux 2.4.0 items =======

 CP-2381  - Bump react-dart version constraint to ^3.0.0  - https://github.com/Workiva/w_flux/pull/65

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.3.1...CP-2036_release_2.4.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.3.1...2.4.0

