### PR TITLE
CHART-1761 add shouldRedraw check on BatchedRedraws

### DIFF
--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -6,10 +6,10 @@ import 'dart:html';
 import 'package:react/react.dart' as react;
 
 class _RedrawScheduler implements Function {
-  Map<react.Component, List<Function>> _components =
-      <react.Component, List<Function>>{};
+  Map<BatchedRedraws, List<Function>> _components =
+      <BatchedRedraws, List<Function>>{};
 
-  void call(react.Component component, [callback()]) {
+  void call(BatchedRedraws component, [callback()]) {
     if (_components.isEmpty) {
       _tick();
     }
@@ -23,6 +23,10 @@ class _RedrawScheduler implements Function {
     await window.animationFrame;
     _components
       ..forEach((component, callbacks) {
+        if (!component.shouldRedraw) {
+          return;
+        }
+
         var chainedCallbacks;
 
         if (callbacks.isNotEmpty) {
@@ -33,7 +37,7 @@ class _RedrawScheduler implements Function {
           };
         }
 
-        component.setState({}, chainedCallbacks);
+        (component as react.Component)?.setState({}, chainedCallbacks);
       })
       ..clear();
   }
@@ -53,6 +57,6 @@ _RedrawScheduler _scheduleRedraw = new _RedrawScheduler();
 ///     }
 ///
 class BatchedRedraws {
-  void redraw([callback()]) =>
-      _scheduleRedraw(this as react.Component, callback);
+  bool get shouldRedraw => true;
+  void redraw([callback()]) => _scheduleRedraw(this, callback);
 }

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -25,6 +25,10 @@ import 'package:test/test.dart';
 
 class _TestComponent extends react.Component with BatchedRedraws {
   int renderCount = 0;
+  bool shouldRedrawValue = true;
+
+  @override
+  bool get shouldRedraw => shouldRedrawValue;
 
   dynamic render() => '';
 
@@ -61,6 +65,13 @@ void main() {
       component.redraw();
       await nextTick();
       expect(component.renderCount, equals(1));
+    });
+
+    test('should not redraw when shouldRedraw returns false', () async {
+      component.shouldRedrawValue = false;
+      component.redraw();
+      await nextTick();
+      expect(component.renderCount, equals(0));
     });
 
     test(


### PR DESCRIPTION
I'd like to get feedback on whether or not this makes sense to do.

I have two situations where I think a `shouldRedraw` getter on `BatchedRedraws`

* the react component is sometimes no longer mounted before the next animation frame, which might lead to a warning/error

* If I have a parent and child that both need to redraw, and the parent redraws first (causing the child possibly also redraw), we don't need to then also redraw the child yet again. This happens most often when you have a parent and child that are both flux components, that are either listening to the same store or different stores that both triggered at around the same time.

@maxwellpeterson-wf 
@evanweible-wf 
@trentgrover-wf 
