### PR TITLE
CHART-1761 add shouldRedraw check on BatchedRedraws

### DIFF
--- a/lib/src/component_client.dart
+++ b/lib/src/component_client.dart
@@ -25,4 +25,11 @@ import 'package:w_flux/src/store.dart';
 /// This FluxComponent, intended for use on the client, utilizes the
 /// [BatchedRedraws] mixin to throttle redraws down to one per animation frame.
 abstract class FluxComponent<ActionsT, StoresT>
-    extends FluxComponentCommon<ActionsT, StoresT> with BatchedRedraws {}
+    extends FluxComponentCommon<ActionsT, StoresT> with BatchedRedraws {
+  @override
+  void componentWillUnmount() {
+    // ensure that unmounted components don't batch render
+    shouldBatchRedraw = false;
+    super.componentWillUnmount();
+  }
+}

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -23,7 +23,7 @@ class _RedrawScheduler implements Function {
     await window.animationFrame;
     _components
       ..forEach((component, callbacks) {
-        if (!component.shouldRedraw) {
+        if (!component.shouldBatchRedraw) {
           return;
         }
 
@@ -57,6 +57,7 @@ _RedrawScheduler _scheduleRedraw = new _RedrawScheduler();
 ///     }
 ///
 class BatchedRedraws {
-  bool get shouldRedraw => true;
+  bool shouldBatchRedraw = true;
+
   void redraw([callback()]) => _scheduleRedraw(this, callback);
 }

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -6,10 +6,10 @@ import 'dart:html';
 import 'package:react/react.dart' as react;
 
 class _RedrawScheduler implements Function {
-  Map<react.Component, List<Function>> _components =
-      <react.Component, List<Function>>{};
+  Map<BatchedRedraws, List<Function>> _components =
+      <BatchedRedraws, List<Function>>{};
 
-  void call(react.Component component, [callback()]) {
+  void call(BatchedRedraws component, [callback()]) {
     if (_components.isEmpty) {
       _tick();
     }
@@ -23,6 +23,10 @@ class _RedrawScheduler implements Function {
     await window.animationFrame;
     _components
       ..forEach((component, callbacks) {
+        if (!component.shouldRedraw) {
+          return;
+        }
+
         var chainedCallbacks;
 
         if (callbacks.isNotEmpty) {
@@ -33,7 +37,7 @@ class _RedrawScheduler implements Function {
           };
         }
 
-        component.setState({}, chainedCallbacks);
+        (component as react.Component)?.setState({}, chainedCallbacks);
       })
       ..clear();
   }
@@ -53,6 +57,6 @@ _RedrawScheduler _scheduleRedraw = new _RedrawScheduler();
 ///     }
 ///
 class BatchedRedraws {
-  void redraw([callback()]) =>
-      _scheduleRedraw(this as react.Component, callback);
+  bool get shouldRedraw => true;
+  void redraw([callback()]) => _scheduleRedraw(this, callback);
 }

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -163,6 +163,14 @@ void main() {
       await nextTick();
       expect(numberOfCalls, 1);
     });
+
+    test('should not redraw after being unmounted', () async {
+      TestDefaultComponent component = new TestDefaultComponent();
+      component.componentWillUnmount();
+      component.redraw();
+      await nextTick();
+      expect(component.numberOfRedraws, equals(0));
+    });
   });
 }
 
@@ -181,8 +189,9 @@ class TestDefaultComponent extends FluxComponent {
 
   render() => react.div({});
 
-  redraw([callback()]) {
-    numberOfRedraws += 1;
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
   }
 }
 
@@ -205,8 +214,9 @@ class TestRedrawOnComponent extends FluxComponent<TestActions, TestStores> {
 
   redrawOn() => [store.store1, store.store2];
 
-  redraw([callback()]) {
-    numberOfRedraws += 1;
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
   }
 }
 
@@ -224,7 +234,8 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
     numberOfHandlerCalls += 1;
   }
 
-  redraw([callback()]) {
-    numberOfRedraws += 1;
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
   }
 }

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -25,6 +25,10 @@ import 'package:test/test.dart';
 
 class _TestComponent extends react.Component with BatchedRedraws {
   int renderCount = 0;
+  bool shouldRedrawValue = true;
+
+  @override
+  bool get shouldRedraw => shouldRedrawValue;
 
   dynamic render() => '';
 
@@ -61,6 +65,13 @@ void main() {
       component.redraw();
       await nextTick();
       expect(component.renderCount, equals(1));
+    });
+
+    test('should not redraw when shouldRedraw returns false', () async {
+      component.shouldRedrawValue = false;
+      component.redraw();
+      await nextTick();
+      expect(component.renderCount, equals(0));
     });
 
     test(

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -25,10 +25,6 @@ import 'package:test/test.dart';
 
 class _TestComponent extends react.Component with BatchedRedraws {
   int renderCount = 0;
-  bool shouldRedrawValue = true;
-
-  @override
-  bool get shouldRedraw => shouldRedrawValue;
 
   dynamic render() => '';
 
@@ -67,8 +63,8 @@ void main() {
       expect(component.renderCount, equals(1));
     });
 
-    test('should not redraw when shouldRedraw returns false', () async {
-      component.shouldRedrawValue = false;
+    test('should not redraw when shouldBatchRedraw returns false', () async {
+      component.shouldBatchRedraw = false;
       component.redraw();
       await nextTick();
       expect(component.renderCount, equals(0));


### PR DESCRIPTION
## Issue
- Continuation of https://github.com/Workiva/w_flux/pull/68
- In some cases, components that use BatchedRedraws to delay rendering to the next animation frame could attempt to render components that are no longer mounted to the DOM (this causes a react setState console error).

## Solution
- add a `shouldBatchRedraw` bool to the BatchedRender mixin that can be set to false to short circuit the delayed render
- set `shouldBatchRedraw` to false when unmounting FluxComponent

NOTE: need to submit a follow up PR to web_skin_dart to add the unmounting logic to `FluxUiComponent` so that this can fix https://github.com/Workiva/wdesk_examples/issues/72 (and likely other misc things)

## Testing
- CI passes (new unit tests added)

## Code Review
@evanweible-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 
@kylemcmorrow-wf 