### PR TITLE
CP-2632 Adjust waiting strategy in troublesome test

### DIFF
--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -50,8 +50,7 @@ void main() {
 
       // Cause store to trigger, wait for it to propagate
       store.trigger();
-      await nextTick();
-      expect(component.numberOfRedraws, 1);
+      await waitFor(() => component.numberOfRedraws == 1);
 
       // Simulate un-mounting the component
       component.componentWillUnmount();

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -7,12 +7,19 @@ Future nextTick([int milliseconds = 1]) {
 }
 
 Future waitFor(bool condition(),
-    {Duration interval: const Duration(milliseconds: 1)}) {
+    {Duration interval: const Duration(milliseconds: 1),
+    int maximumTimeout: 10}) {
   Completer c = new Completer();
+  Stopwatch w = new Stopwatch()..start();
   new Timer.periodic(interval, (timer) {
-    if (condition()) {
+    if (condition() || w.elapsedMilliseconds > maximumTimeout) {
       timer.cancel();
       c.complete();
+      w.stop();
+      if (w.elapsedMilliseconds > maximumTimeout) {
+        throw new TimeoutException(
+            'The expected condition did not occur within $maximumTimeout milliseconds');
+      }
     }
   });
   return c.future;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -5,3 +5,15 @@ import 'dart:async';
 Future nextTick([int milliseconds = 1]) {
   return new Future.delayed(new Duration(milliseconds: milliseconds));
 }
+
+Future waitFor(bool condition(),
+    {Duration interval: const Duration(milliseconds: 1)}) {
+  Completer c = new Completer();
+  new Timer.periodic(interval, (timer) {
+    if (condition()) {
+      timer.cancel();
+      c.complete();
+    }
+  });
+  return c.future;
+}


### PR DESCRIPTION
## Issue
- There was a test, `should subscribe to a single store by default` that was intermittently failing.
## Changes

**Source:**
- Adjusted waiting strategy

**Tests:**
- n/a, purpose of this pr
## Areas of Regression
- failing tests
## Testing
- passing CI
## Code Review

@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf
