### PR TITLE
CP-2596 Store implements Disposable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - stable
+  - 1.19.1
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,15 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const String v3Deprecation = 'Will be removed in 4.0.0';

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -16,6 +16,8 @@ library w_flux.store;
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+import 'package:w_common/disposable.dart' show Disposable;
 import 'package:w_flux/src/action.dart';
 
 typedef StoreHandler(Store event);
@@ -37,17 +39,17 @@ typedef StoreHandler(Store event);
 /// In a typical application using `w_flux`, a [FluxComponent] listens to
 /// `Store`s, triggering re-rendering of the UI elements based on the updated
 /// `Store` data.
-class Store {
+class Store extends Disposable {
   /// Stream controller for [_stream]. Used by [trigger].
-  StreamController<Store> _streamController;
+  final StreamController<Store> _streamController;
 
   /// Broadcast stream of "data updated" events. Listened to in [listen].
   Stream<Store> _stream;
 
   /// Construct a new [Store] instance.
-  Store() {
-    _streamController = new StreamController<Store>();
-    _stream = _streamController.stream.asBroadcastStream();
+  Store() : _streamController = new StreamController<Store>.broadcast() {
+    manageStreamController(_streamController);
+    _stream = _streamController.stream;
   }
 
   /// Construct a new [Store] instance with a transformer.
@@ -58,13 +60,45 @@ class Store {
   /// As an example, [transformer] could be used to throttle the number of
   /// triggers this [Store] emits for state that may update extremely frequently
   /// (like scroll position).
-  Store.withTransformer(StreamTransformer<dynamic, dynamic> transformer) {
-    _streamController = new StreamController<Store>();
+  Store.withTransformer(StreamTransformer<dynamic, dynamic> transformer)
+      : _streamController = new StreamController<Store>() {
+    manageStreamController(_streamController);
 
     // apply a transform to the stream if supplied
     _stream = _streamController.stream
         .transform(transformer as StreamTransformer<Store, dynamic>)
         .asBroadcastStream() as Stream<Store>;
+  }
+
+  /// Adds a subscription to this `Store`.
+  ///
+  /// Each time this `Store` triggers (by calling [trigger]), indicating that
+  /// data has been mutated, [onData] will be called.
+  ///
+  /// If the `Store` has been disposed, this method throws a [StateError].
+  ///
+  /// It is the caller's responsibility to cancel the subscription when
+  /// needed.
+  StreamSubscription<Store> listen(StoreHandler onData,
+      {Function onError, void onDone(), bool cancelOnError}) {
+    if (isDisposed) {
+      throw new StateError('Store has been disposed');
+    }
+
+    return _stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  /// Registers an [ActionSubscription] to be canceled when the store is disposed.
+  ///
+  /// This supports the following pattern for consumers:
+  ///
+  ///     manageActionSubscription(myAction.listen(_myHandler));
+  ///
+  @mustCallSuper
+  @protected
+  void manageActionSubscription(ActionSubscription subscription) {
+    manageDisposer(() async => subscription.cancel());
   }
 
   /// Trigger a "data updated" event. All registered listeners of this `Store`
@@ -73,7 +107,11 @@ class Store {
   ///
   /// This should be called whenever this `Store`'s data has finished mutating in
   /// response to an action.
+  ///
+  /// If the `Store` has been disposed, this method has no effect.
   void trigger() {
+    if (isDisposed) return;
+
     _streamController.add(this);
   }
 
@@ -83,26 +121,17 @@ class Store {
   /// If [onAction] is provided, it will be called every time [action] is
   /// dispatched. If [onAction] returns a [Future], [trigger] will not be
   /// called until that future has resolved.
-  triggerOnAction(Action action, [void onAction(payload)]) {
-    if (onAction != null) {
-      action.listen((payload) async {
-        await onAction(payload);
-        trigger();
-      });
-    } else {
-      action.listen((_) {
-        trigger();
-      });
-    }
-  }
-
-  /// Adds a subscription to this `Store`.
   ///
-  /// Each time this `Store` triggers (by calling [trigger]), indicating that
-  /// data has been mutated, [onData] will be called.
-  StreamSubscription<Store> listen(StoreHandler onData,
-      {Function onError, void onDone(), bool cancelOnError}) {
-    return _stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  /// If the `Store` has been disposed, this method throws a [StateError].
+  triggerOnAction(Action action, [void onAction(payload)]) {
+    if (isDisposed) {
+      throw new StateError('Store has been disposed');
+    }
+    manageActionSubscription(action.listen((payload) async {
+      if (onAction != null) {
+        await onAction(payload);
+      }
+      trigger();
+    }));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,12 +12,10 @@ authors:
 
 homepage: https://github.com/Workiva/w_flux
 
-environment:
-  sdk: ">=1.9.0 <2.0.0"
-
 dependencies:
+  meta: ^1.0.4
   react: ^3.0.0
-
+  w_common: ^1.0.0
 dev_dependencies:
   coverage: ^0.7.9
   dart_dev: ^1.5.1
@@ -25,3 +23,6 @@ dev_dependencies:
   dartdoc: ^0.9.7+6
   test: ^0.12.15+12
   rate_limit: ^0.1.0
+
+environment:
+  sdk: ">=1.9.0 <2.0.0"

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -165,6 +165,20 @@ void main() {
         await action();
         expect(listened, isFalse);
       });
+
+      test('should stop listening when actions are disposed', () async {
+        var action = new Action();
+        var listened = false;
+        action.listen((_) => listened = true);
+
+        await action();
+        expect(listened, isTrue);
+
+        listened = false;
+        await action.dispose();
+        await action();
+        expect(listened, isFalse);
+      });
     });
 
     group('benchmarks', () {


### PR DESCRIPTION
*Fixes #61, #69, #73*

## Issue

Store does not clean up its StreamController or its ActionSubscriptions, and provides no way to do so.

## Solution

Store now extends [w_common's Disposable](https://github.com/Workiva/w_common). The internal StreamController and any ActionSubscriptions are cleaned up on dispose.

Bonus: Store test usage of expectAsync was corrected.

## Testing

No regressions in Store usage. Full test coverage for the new code was added.

## Code Review

@trentgrover-wf 
@evanweible-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
(did I miss anyone?)