### PR TITLE
CP-2937 Sleep after starting xvfb to avoid content-shell failures on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ with_content_shell: true
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze


### PR DESCRIPTION
## Problem
Travis CI runs fail intermittently due to content-shell failing to start. Adding a short sleep after starting xvfb seems to fix this issue and was recommended by a member of the dart-lang team.

## Solution
Add `sleep 3` immediately starting xvfb.

## Testing
- [ ] CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 