### PR TITLE
CP-2944 Fix intermittent failures, add basic smithy.yaml, add sleep to Travis CI startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ with_content_shell: true
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: w_flux
 version: 2.5.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
+
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>
   - Dustin Lessard <dustin.lessard@workiva.com>
@@ -8,15 +9,19 @@ authors:
   - Jay Udey <jay.udey@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
+
 homepage: https://github.com/Workiva/w_flux
-dependencies:
-  react: "^3.0.0"
-dev_dependencies:
-  coverage: "^0.7.2"
-  dart_dev: "^1.0.0"
-  dart_style: "^0.2.0"
-  dartdoc: "^0.8.0"
-  test: "^0.12.3+5"
-  rate_limit: 0.1.0
+
 environment:
   sdk: ">=1.9.0 <2.0.0"
+
+dependencies:
+  react: ^3.0.0
+
+dev_dependencies:
+  coverage: ^0.7.9
+  dart_dev: ^1.5.1
+  dart_style: ^0.2.11+1
+  dartdoc: ^0.9.7+6
+  test: ^0.12.15+12
+  rate_limit: ^0.1.0

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,12 @@
+project: dart
+language: dart
+
+# dart 1.19.1, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:74173
+
+script:
+  - pub get
+
+artifacts:
+  build:
+    - ./pubspec.lock

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -16,12 +16,11 @@
 library w_flux.test.component_test;
 
 import 'dart:async';
+import 'dart:html' show window;
 
 import 'package:react/react.dart' as react;
 import 'package:test/test.dart';
 import 'package:w_flux/w_flux.dart';
-
-import 'utils.dart';
 
 void main() {
   group('FluxComponent', () {
@@ -50,7 +49,7 @@ void main() {
 
       // Cause store to trigger, wait for it to propagate
       store.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 1);
 
       // Simulate un-mounting the component
@@ -58,7 +57,7 @@ void main() {
 
       // Component should no longer be listening
       store.trigger();
-      await nextTick();
+      await animationFrames(2);
 
       // Redraw should not have been called again
       expect(component.numberOfRedraws, 1);
@@ -71,15 +70,15 @@ void main() {
       component.componentWillMount();
 
       stores.store1.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 1);
 
       stores.store2.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 2);
 
       stores.store3.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 2);
     });
 
@@ -91,12 +90,12 @@ void main() {
       component.componentWillMount();
 
       stores.store1.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 0);
       expect(component.numberOfHandlerCalls, 1);
 
       stores.store2.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 1);
       expect(component.numberOfHandlerCalls, 1);
     });
@@ -109,11 +108,11 @@ void main() {
       component.componentWillMount();
 
       stores.store1.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 0);
 
       stores.store2.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, 0);
     });
 
@@ -128,7 +127,7 @@ void main() {
 
       // Cause store to trigger, wait for it to propagate
       store.trigger();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfHandlerCalls, 1);
 
       // Simulate un-mounting the component
@@ -136,7 +135,7 @@ void main() {
 
       // Component should no longer be listening
       store.trigger();
-      await nextTick();
+      await animationFrames(2);
 
       // Handler should not have been called again
       expect(component.numberOfHandlerCalls, 1);
@@ -154,13 +153,13 @@ void main() {
 
       // Add something to the stream and expect the handler to have been called
       controller.add('something');
-      await nextTick();
+      await animationFrames(2);
       expect(numberOfCalls, 1);
 
       // Unmount the component, expect the subscription to have been canceled
       component.componentWillUnmount();
       controller.add('something else');
-      await nextTick();
+      await animationFrames(2);
       expect(numberOfCalls, 1);
     });
 
@@ -168,10 +167,16 @@ void main() {
       TestDefaultComponent component = new TestDefaultComponent();
       component.componentWillUnmount();
       component.redraw();
-      await nextTick();
+      await animationFrames(2);
       expect(component.numberOfRedraws, equals(0));
     });
   });
+}
+
+Future animationFrames([int numFrames = 1]) async {
+  for (int i = 0; i < numFrames; i++) {
+    await window.animationFrame;
+  }
 }
 
 class TestActions {}

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -24,6 +24,7 @@ main(List<String> args) async {
   config.analyze.entryPoints = dirs;
   config.analyze.strong = true;
   config.copyLicense.directories = dirs;
+  config.coverage.pubServe = true;
   config.format.directories = dirs;
   config.test.platforms = ['vm', 'content-shell'];
 


### PR DESCRIPTION
## Changes

- Fix intermittent component test failures by awaiting `window.animationFrame`s instead of hardcoded awaits
- Add a basic smithy.yaml (cherry-picked @jayudey-wf's commit) for dependency tracking
- Add a sleep to Travis CI startup after starting xvfb to prevent content-shell failures
- Upgrade dependencies and set `pubServe = true` for coverage task for Dart 1.20 compat

## Testing

- [x] CI passes

## Code Review

@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 