### PR TITLE
Relax Action handler return type

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -78,7 +78,7 @@ class Action<T> extends Object with Disposable implements Function {
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
-  ActionSubscription listen(void onData(T event)) {
+  ActionSubscription listen(dynamic onData(T event)) {
     _listeners.add(onData);
     return new ActionSubscription(() => _listeners.remove(onData));
   }


### PR DESCRIPTION
### Issue
If strong mode is enabled on one of your Action handlers is marked as an `async` function, the following analysis error is shown:

![error-screenshot](https://dl.dropbox.com/s/5ok9jz1uyeo9qb1/Screenshot%202017-01-25%2016.13.50.png)

`async` functions can be very useful for Action handlers, because you may want to leverage `await`.

### Changes
**Source:**
* Relax return type of Action handler from `void` to `dynamic`.

### Testing
- CI Passes

### Code Review
@Workiva/web-platform-pp
@Workiva/rich-app-platform-pp 