### PR TITLE
CP-2958 Release w_flux 2.6.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.6.0
+version: 2.6.1
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3349 Relax Action handler return type](https://github.com/Workiva/w_flux/pull/80)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.6.0...version-bump-w_flux-2-6-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.6.0...2.6.1