### PR TITLE
wp-3758 : manage stream subscription

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -85,8 +85,10 @@ class Store extends Disposable {
       throw new StateError('Store has been disposed');
     }
 
-    return _stream.listen(onData,
+    StreamSubscription<Store> streamSubscription = _stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    manageStreamSubscription(streamSubscription);
+    return streamSubscription;
   }
 
   /// Registers an [ActionSubscription] to be canceled when the store is disposed.


### PR DESCRIPTION
Purpose
-------

One stream subscriptions appeared to  not be correctly managed.

Solution
--------

Stream subscriptions is managed

Semantic Versioning (check one)
-------------------------------
- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
  - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [x] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch release

How to QA
-------
- [ ] run unit-tests
- [ ] run integration tests
- [ ] run the following related examples: default example


