### PR TITLE
HY-4736 Expose trigger stream on store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - 1.19.1
+  - 1.22.1
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -71,6 +71,7 @@ class Store extends Disposable {
   }
 
   /// The stream underlying [trigger] events and [listen].
+  @visibleForTesting
   Stream<Store> get stream => _stream;
 
   /// Adds a subscription to this `Store`.

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -70,6 +70,9 @@ class Store extends Disposable {
         .asBroadcastStream() as Stream<Store>;
   }
 
+  /// The stream underlying [trigger] events and [listen].
+  Stream<Store> get stream => _stream;
+
   /// Adds a subscription to this `Store`.
   ///
   /// Each time this `Store` triggers (by calling [trigger]), indicating that

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   rate_limit: ^0.1.0
 
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: ">=1.21.0 <2.0.0"

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# dart 1.19.1, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:74173
+# dart 1.22.0, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.9
+runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:124921
 
 script:
   - pub get

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -58,13 +58,14 @@ void main() {
       store.trigger();
     });
 
-    test('should trigger in response to an action', () {
+    test('should trigger in response to an action', () async {
       Action _action = new Action();
       store.triggerOnAction(_action);
-      store.listen(expectAsync((Store payload) {
-        expect(payload, store);
-      }) as StoreHandler);
+
       _action();
+      Store payload = await store.stream.first;
+
+      expect(payload, store);
     });
 
     test(


### PR DESCRIPTION
### Purpose
Allow more flexible access to a `Store`'s trigger stream, particularly for testing.

### Solution
Add a `stream` getter to the `Store` class.

### Semantic Versioning
**MINOR**. Adds new API to the `Store` class.

### Testing
- CI passes