### PR TITLE
WP-4411 Update dependencies

### DIFF
--- a/lib/src/component_common.dart
+++ b/lib/src/component_common.dart
@@ -63,7 +63,8 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
     // and wired up to their respective handlers.
     Map<Store, StoreHandler> handlers =
         new Map<Store, StoreHandler>.fromIterable(redrawOn(),
-            value: (_) => (_) => redraw())..addAll(getStoreHandlers());
+            value: (_) => (_) => redraw())
+          ..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
       manageStreamSubscription(store.listen(handler));
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   w_common: ^1.0.0
 dev_dependencies:
   coverage: ^0.7.9
-  dart_dev: ^1.5.1
-  dart_style: ^0.2.11+1
-  dartdoc: ^0.9.7+6
+  dart_dev: ^1.7.7
+  dart_style: '>=0.2.4 <2.0.0'
+  dartdoc: '>=0.9.0 <0.13.0'
   test: ^0.12.15+12
   rate_limit: ^0.1.0
 


### PR DESCRIPTION
The`dart_style` and `dartdoc` dependency ranges are blocking progress on strong-mode / DDC work.  

Specifically, supporting the `covariant` keyword in over_react props / state classes ([UIP-2024](https://jira.atl.workiva.net/browse/UIP-2024)).

These changes bring the dependency ranges of `dart_style` and `dartdoc` in-line with the ranges found within the current version of `dart_dev`.

---

FYA @Workiva/web-platform-pp 
FYI @Workiva/ui-platform-pp 