### PR TITLE
WP-3983 Release w_flux 2.7.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.7.0
+version: 2.7.1
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4052 Add a note about over_react's FluxUiComponent](https://github.com/Workiva/w_flux/pull/86)
* [WP-4411 Update dependencies](https://github.com/Workiva/w_flux/pull/88)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.7.0...version-bump-w_flux-2-7-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.7.0...2.7.1