### PR TITLE
WP-4432 Add lints and close test controllers.

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,2 +1,6 @@
 analyzer:
   strong-mode: true
+linter:
+  rules:
+    cancel_subscriptions
+    close_sinks

--- a/.analysis_options
+++ b/.analysis_options
@@ -2,5 +2,5 @@ analyzer:
   strong-mode: true
 linter:
   rules:
-    cancel_subscriptions
-    close_sinks
+    - cancel_subscriptions
+    - close_sinks

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -162,6 +162,8 @@ void main() {
       controller.add('something else');
       await nextTick();
       expect(numberOfCalls, 1);
+
+      await controller.close();
     });
   });
 }

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -161,6 +161,8 @@ void main() {
       controller.add('something else');
       await animationFrames(2);
       expect(numberOfCalls, 1);
+
+      await controller.close();
     });
 
     test('should not redraw after being unmounted', () async {


### PR DESCRIPTION
# Problem

The `close_sinks` and `cancel_subscriptions` lints were not enabled. When I enabled them, I found two small places in tests where `StreamController`s were never closed.

# Solution

- Enable them.
- Close the offending controllers in the tests.

# Testing Suggestion

- [ ] CI passes - tooling only