### PR TITLE
WP-4459 Ignore trigger when disposed or disposing

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -112,9 +112,9 @@ class Store extends Disposable {
   /// This should be called whenever this `Store`'s data has finished mutating in
   /// response to an action.
   ///
-  /// If the `Store` has been disposed, this method has no effect.
+  /// If the `Store` is disposing or has been disposed, this method has no effect.
   void trigger() {
-    if (isDisposed) return;
+    if (isDisposedOrDisposing) return;
 
     _streamController.add(this);
   }

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -161,7 +161,7 @@ void main() {
         expect(listened, isTrue);
 
         listened = false;
-        action.clearListeners();
+        await action.dispose();
         await action();
         expect(listened, isFalse);
       });

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -148,7 +148,7 @@ void main() {
       int numberOfCalls = 0;
       StreamController controller = new StreamController();
       TestDefaultComponent component = new TestDefaultComponent();
-      component.addSubscription(controller.stream.listen((_) {
+      component.manageStreamSubscription(controller.stream.listen((_) {
         numberOfCalls += 1;
       }));
 

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -147,7 +147,7 @@ void main() {
       int numberOfCalls = 0;
       StreamController controller = new StreamController();
       TestDefaultComponent component = new TestDefaultComponent();
-      component.addSubscription(controller.stream.listen((_) {
+      component.manageStreamSubscription(controller.stream.listen((_) {
         numberOfCalls += 1;
       }));
 

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('should trigger with itself as the payload', () {
-      store.listen(expectAsync((Store payload) {
+      store.listen(expectAsync1((payload) {
         expect(payload, store);
       }) as StoreHandler);
 
@@ -49,7 +49,7 @@ void main() {
       // all others that occurred within the throttled duration)
       store = new Store.withTransformer(
           new Throttler(const Duration(milliseconds: 30)));
-      store.listen(expectAsync((Store payload) {}, count: 2) as StoreHandler);
+      store.listen(expectAsync1((payload) {}, count: 2) as StoreHandler);
 
       store.trigger();
       store.trigger();
@@ -78,7 +78,7 @@ void main() {
       }
 
       store.triggerOnAction(_action, syncCallback);
-      store.listen(expectAsync((Store payload) {
+      store.listen(expectAsync1((payload) {
         expect(payload, store);
         expect(methodCalled, isTrue);
       }) as StoreHandler);
@@ -96,7 +96,7 @@ void main() {
       }
 
       store.triggerOnAction(_action, asyncCallback);
-      store.listen(expectAsync((Store payload) {
+      store.listen(expectAsync1((payload) {
         expect(payload, store);
         expect(afterTimer, isTrue);
       }) as StoreHandler);
@@ -109,7 +109,7 @@ void main() {
       Action<num> _action = new Action<num>();
       num counter = 0;
       store.triggerOnAction(_action, (payload) => counter = payload);
-      store.listen(expectAsync((Store payload) {
+      store.listen(expectAsync1((payload) {
         expect(payload, store);
         expect(counter, 17);
       }) as StoreHandler);
@@ -119,7 +119,7 @@ void main() {
     test('cleans up its StreamController on dispose', () {
       bool afterDispose = false;
 
-      store.listen(expectAsync((Store payload) async {
+      store.listen(expectAsync1((payload) async {
         // Safety check to avoid infinite trigger loop
         expect(afterDispose, isFalse);
 
@@ -139,7 +139,7 @@ void main() {
 
       Action _action = new Action();
       store.triggerOnAction(_action);
-      store.listen(expectAsync((Store payload) async {
+      store.listen(expectAsync1((payload) async {
         // Safety check to avoid infinite trigger loop
         expect(afterDispose, isFalse);
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -25,7 +25,7 @@ main(List<String> args) async {
   config.analyze.strong = true;
   config.copyLicense.directories = dirs;
   config.coverage.pubServe = true;
-  config.format.directories = dirs;
+  config.format.paths = dirs;
   config.test.platforms = ['vm', 'content-shell'];
 
   await dev(args);


### PR DESCRIPTION
Problem
--------
Store.trigger() will throw an exception if disposing (but not if fully disposed):
```
Bad state: Cannot add new events after calling close
dart:async                                                            _BroadcastStreamController.add
package:w_flux/src/store.dart 119:23                                  Store.trigger
package:w_flux/src/store.dart 138:7                                   Store.triggerOnAction.<fn>
package:w_flux/src/action.dart 66:65                                  Action.call.<fn>.<fn>
```

Solution
--------
Check `isDisposedOrDisposing` before attempting to add events to the streamController in trigger() 

Potential Regressions
---------------------
This is `trigger()` code, so any time any Store `trigger()`s. But `isDisposedOrDisposing` semantics appear to be well tested.

Tests
-----
No changes.

QA / +10

@bencampbell-wf @evanweible-wf @maxwellpeterson-wf @jayudey-wf 