### PR TITLE
WP-4872 fix broken tests and deprecations

### DIFF
--- a/lib/src/component_common.dart
+++ b/lib/src/component_common.dart
@@ -66,8 +66,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
             value: (_) => (_) => redraw())
           ..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
-      var subscription = store.listen(handler);
-      getManagedDisposer(() async => subscription.cancel());
+      listenToStream(store.stream, handler);
     });
   }
 

--- a/lib/src/component_common.dart
+++ b/lib/src/component_common.dart
@@ -66,7 +66,8 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
             value: (_) => (_) => redraw())
           ..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
-      manageStreamSubscription(store.listen(handler));
+      var subscription = store.listen(handler);
+      getManagedDisposer(() async => subscription.cancel());
     });
   }
 

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -102,7 +102,7 @@ class Store extends Disposable {
   @mustCallSuper
   @protected
   void manageActionSubscription(ActionSubscription subscription) {
-    manageDisposer(() async => subscription.cancel());
+    getManagedDisposer(() async => subscription.cancel());
   }
 
   /// Trigger a "data updated" event. All registered listeners of this `Store`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,12 +15,13 @@ homepage: https://github.com/Workiva/w_flux
 dependencies:
   meta: ^1.0.4
   react: ^3.0.0
-  w_common: ^1.0.0
+  w_common: ^1.7.0
 dev_dependencies:
   coverage: ^0.7.9
   dart_dev: ^1.7.7
   dart_style: '>=0.2.4 <2.0.0'
   dartdoc: '>=0.9.0 <0.13.0'
+  rxdart: ^0.12.0
   test: ^0.12.15+12
 
 environment:

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -55,6 +55,7 @@ void main() {
 
       // Simulate un-mounting the component
       component.componentWillUnmount();
+      await component.didDispose;
 
       // Component should no longer be listening
       store.trigger();
@@ -133,6 +134,7 @@ void main() {
 
       // Simulate un-mounting the component
       component.componentWillUnmount();
+      await component.didDispose;
 
       // Component should no longer be listening
       store.trigger();
@@ -148,9 +150,11 @@ void main() {
       int numberOfCalls = 0;
       StreamController controller = new StreamController();
       TestDefaultComponent component = new TestDefaultComponent();
-      component.manageStreamSubscription(controller.stream.listen((_) {
+
+      var subscription = controller.stream.listen((_) {
         numberOfCalls += 1;
-      }));
+      });
+      component.getManagedDisposer(() async => subscription.cancel());
 
       // Add something to the stream and expect the handler to have been called
       controller.add('something');
@@ -159,6 +163,7 @@ void main() {
 
       // Unmount the component, expect the subscription to have been canceled
       component.componentWillUnmount();
+      await component.didDispose;
       controller.add('something else');
       await nextTick();
       expect(numberOfCalls, 1);

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -54,6 +54,7 @@ void main() {
 
       // Simulate un-mounting the component
       component.componentWillUnmount();
+      await component.didDispose;
 
       // Component should no longer be listening
       store.trigger();
@@ -132,6 +133,7 @@ void main() {
 
       // Simulate un-mounting the component
       component.componentWillUnmount();
+      await component.didDispose;
 
       // Component should no longer be listening
       store.trigger();
@@ -147,9 +149,10 @@ void main() {
       int numberOfCalls = 0;
       StreamController controller = new StreamController();
       TestDefaultComponent component = new TestDefaultComponent();
-      component.manageStreamSubscription(controller.stream.listen((_) {
+      var subscription = controller.stream.listen((_) {
         numberOfCalls += 1;
-      }));
+      });
+      component.getManagedDisposer(() async => subscription.cancel());
 
       // Add something to the stream and expect the handler to have been called
       controller.add('something');
@@ -158,6 +161,7 @@ void main() {
 
       // Unmount the component, expect the subscription to have been canceled
       component.componentWillUnmount();
+      await component.didDispose;
       controller.add('something else');
       await animationFrames(2);
       expect(numberOfCalls, 1);
@@ -168,6 +172,7 @@ void main() {
     test('should not redraw after being unmounted', () async {
       TestDefaultComponent component = new TestDefaultComponent();
       component.componentWillUnmount();
+      await component.didDispose;
       component.redraw();
       await animationFrames(2);
       expect(component.numberOfRedraws, equals(0));

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -17,7 +17,7 @@ library w_flux.test.store_test;
 
 import 'dart:async';
 
-import 'package:rate_limit/rate_limit.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 import 'package:w_flux/src/action.dart';
 import 'package:w_flux/src/store.dart';
@@ -42,16 +42,13 @@ void main() {
       store.trigger();
     });
 
-    test('should support stream transforms', () {
+    test('should support stream transforms', () async {
       // ensure that multiple trigger executions emit
       // exactly 2 throttled triggers to external listeners
-      // (1 for the initial trigger and 1 as the aggregate of
-      // all others that occurred within the throttled duration)
-      store = new Store.withTransformer(
-          new Throttler(const Duration(milliseconds: 30)));
+      store =
+          new Store.withTransformer(new BufferWithCountStreamTransformer(2));
       store.listen(expectAsync1((payload) {}, count: 2) as StoreHandler);
 
-      store.trigger();
       store.trigger();
       store.trigger();
       store.trigger();


### PR DESCRIPTION
Problem
--------
- tests on master were failing

Solution
--------
- rate_limit was still used in a test, so I swapped in rxdart and made it a dev dependency
- on tests that simulated component unmount, await didDispose before continuing
- fixed some deprecation warnings

Potential Regressions
--------
None, the dependency appears unused.

QA / +10
--------
- [ ] CI should pass
