### PR TITLE
RAP-2146 Make store extend Stream

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -39,7 +39,7 @@ typedef StoreHandler(Store event);
 /// In a typical application using `w_flux`, a [FluxComponent] listens to
 /// `Store`s, triggering re-rendering of the UI elements based on the updated
 /// `Store` data.
-class Store extends Disposable {
+class Store extends Stream<Store> with Disposable {
   /// Stream controller for [_stream]. Used by [trigger].
   final StreamController<Store> _streamController;
 
@@ -70,7 +70,14 @@ class Store extends Disposable {
         .asBroadcastStream() as Stream<Store>;
   }
 
+  @override
+  bool get isBroadcast => _stream.isBroadcast;
+
   /// The stream underlying [trigger] events and [listen].
+  ///
+  /// Deprecated: [Store] now extends [Stream]. Since the store itself
+  /// can be treated as a stream this is no longer required.
+  @Deprecated('3.0.0')
   @visibleForTesting
   Stream<Store> get stream => _stream;
 
@@ -83,6 +90,7 @@ class Store extends Disposable {
   ///
   /// It is the caller's responsibility to cancel the subscription when
   /// needed.
+  @override
   StreamSubscription<Store> listen(StoreHandler onData,
       {Function onError, void onDone(), bool cancelOnError}) {
     if (isDisposed) {

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -34,6 +34,10 @@ void main() {
       store.dispose();
     });
 
+    test('should extend Stream', () {
+      expect(store, new isInstanceOf<Stream>());
+    });
+
     test('should trigger with itself as the payload', () {
       store.listen(expectAsync1((payload) {
         expect(payload, store);

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -38,6 +38,19 @@ void main() {
       expect(store, new isInstanceOf<Stream>());
     });
 
+    group('isBroadcast', () {
+      test('should be true when the default constructor is used', () {
+        store = new Store();
+        expect(store.isBroadcast, isTrue);
+      });
+
+      test('should be true when the withTransformer constructor is used', () {
+        store =
+            new Store.withTransformer(new BufferWithCountStreamTransformer(2));
+        expect(store.isBroadcast, isTrue);
+      });
+    });
+
     test('should trigger with itself as the payload', () {
       store.listen(expectAsync1((payload) {
         expect(payload, store);


### PR DESCRIPTION
[Jira Ticket](https://jira.atl.workiva.net/browse/RAP-2146)

## Problem

We want `Store` to extend `Stream` so that consumers can listen to it as though it was a stream itself.

## Solution

Extend `Stream` and implement `listen` and `isBroadcast`. I've also deprecated `stream` since it is no longer necessary.

## Potential Regressions

None.

## Tests

Added and/or updated.

## QA / +10

1. CI passes

## FYI

@regenvanwalbeek-wf @evanweible-wf 