### PR TITLE
WP-4924 Redraw only once when store triggers along with ancestor rerender

### DIFF
--- a/lib/src/component_client.dart
+++ b/lib/src/component_client.dart
@@ -14,6 +14,8 @@
 
 library w_flux.src.component_client;
 
+import 'package:meta/meta.dart';
+
 import 'package:w_flux/src/component_common.dart';
 import 'package:w_flux/src/mixins/batched_redraws.dart';
 import 'package:w_flux/src/store.dart';
@@ -26,10 +28,19 @@ import 'package:w_flux/src/store.dart';
 /// [BatchedRedraws] mixin to throttle redraws down to one per animation frame.
 abstract class FluxComponent<ActionsT, StoresT>
     extends FluxComponentCommon<ActionsT, StoresT> with BatchedRedraws {
+  @mustCallSuper
   @override
   void componentWillUnmount() {
     // ensure that unmounted components don't batch render
     shouldBatchRedraw = false;
     super.componentWillUnmount();
+  }
+
+  @mustCallSuper
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState) {
+    // Let BatchedRedraws know that this component has redrawn in the current batch
+    didBatchRedraw = true;
+    super.componentDidUpdate(prevProps, prevState);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   dart_dev: ^1.7.7
   dart_style: '>=0.2.4 <2.0.0'
   dartdoc: '>=0.9.0 <0.13.0'
+  over_react: '^1.0.0'
   rxdart: ^0.12.0
   test: ^0.12.15+12
 

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -183,7 +183,9 @@ void main() {
       expect(component.numberOfRedraws, equals(0));
     });
 
-    test('only redraws once in response to a store trigger combined with an ancestor rerendering', () async {
+    test(
+        'only redraws once in response to a store trigger'
+        ' combined with an ancestor rerendering', () async {
       var store = new Store();
 
       TestNestedComponent nested0;
@@ -191,20 +193,28 @@ void main() {
       TestNestedComponent nested2;
 
       react_test_utils.renderIntoDocument(
-          TestNested({
+        TestNested(
+          {
             'store': store,
-            'ref': (ref) { nested0 = ref; },
+            'ref': (ref) {
+              nested0 = ref;
+            },
           },
+          TestNested(
+            {
+              'store': store,
+              'ref': (ref) {
+                nested1 = ref;
+              },
+            },
             TestNested({
               'store': store,
-              'ref': (ref) { nested1 = ref; },
-            },
-              TestNested({
-                'store': store,
-                'ref': (ref) { nested2 = ref; },
-              }),
-            )
-          )
+              'ref': (ref) {
+                nested2 = ref;
+              },
+            }),
+          ),
+        ),
       );
       expect(nested0.renderCount, 1, reason: 'setup check: initial render');
       expect(nested1.renderCount, 1, reason: 'setup check: initial render');
@@ -213,9 +223,12 @@ void main() {
       nested0.redraw();
       await animationFrames(2);
 
-      expect(nested0.renderCount, 2, reason: 'setup check: components should rerender their children');
-      expect(nested1.renderCount, 2, reason: 'setup check: components should rerender their children');
-      expect(nested2.renderCount, 2, reason: 'setup check: components should rerender their children');
+      expect(nested0.renderCount, 2,
+          reason: 'setup check: components should rerender their children');
+      expect(nested1.renderCount, 2,
+          reason: 'setup check: components should rerender their children');
+      expect(nested2.renderCount, 2,
+          reason: 'setup check: components should rerender their children');
 
       store.trigger();
       // Two async gaps just to be safe, since we're
@@ -223,9 +236,15 @@ void main() {
       await animationFrames(2);
       await animationFrames(2);
 
-      expect(nested0.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
-      expect(nested1.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
-      expect(nested2.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
+      expect(nested0.renderCount, 3,
+          reason: 'should have rerendered once in response to'
+              ' the store triggering');
+      expect(nested1.renderCount, 3,
+          reason: 'should have rerendered once in response to'
+              ' the store triggering');
+      expect(nested2.renderCount, 3,
+          reason: 'should have rerendered once in response to'
+              ' the store triggering');
     });
   });
 }
@@ -303,6 +322,7 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
 }
 
 final TestNested = react.registerComponent(() => new TestNestedComponent());
+
 class TestNestedComponent extends FluxComponent {
   int renderCount = 0;
 

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -18,11 +18,16 @@ library w_flux.test.component_test;
 import 'dart:async';
 import 'dart:html' show window;
 
+import 'package:over_react/over_react.dart' show cloneElement;
 import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
+import 'package:react/react_test_utils.dart' as react_test_utils;
 import 'package:test/test.dart';
 import 'package:w_flux/w_flux.dart';
 
 void main() {
+  setClientConfiguration();
+
   group('FluxComponent', () {
     test('should expose an actions getter', () {
       TestDefaultComponent component = new TestDefaultComponent();
@@ -177,6 +182,51 @@ void main() {
       await animationFrames(2);
       expect(component.numberOfRedraws, equals(0));
     });
+
+    test('only redraws once in response to a store trigger combined with an ancestor rerendering', () async {
+      var store = new Store();
+
+      TestNestedComponent nested0;
+      TestNestedComponent nested1;
+      TestNestedComponent nested2;
+
+      react_test_utils.renderIntoDocument(
+          TestNested({
+            'store': store,
+            'ref': (ref) { nested0 = ref; },
+          },
+            TestNested({
+              'store': store,
+              'ref': (ref) { nested1 = ref; },
+            },
+              TestNested({
+                'store': store,
+                'ref': (ref) { nested2 = ref; },
+              }),
+            )
+          )
+      );
+      expect(nested0.renderCount, 1, reason: 'setup check: initial render');
+      expect(nested1.renderCount, 1, reason: 'setup check: initial render');
+      expect(nested2.renderCount, 1, reason: 'setup check: initial render');
+
+      nested0.redraw();
+      await animationFrames(2);
+
+      expect(nested0.renderCount, 2, reason: 'setup check: components should rerender their children');
+      expect(nested1.renderCount, 2, reason: 'setup check: components should rerender their children');
+      expect(nested2.renderCount, 2, reason: 'setup check: components should rerender their children');
+
+      store.trigger();
+      // Two async gaps just to be safe, since we're
+      // asserting that additional redraws don't happen.
+      await animationFrames(2);
+      await animationFrames(2);
+
+      expect(nested0.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
+      expect(nested1.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
+      expect(nested2.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
+    });
   });
 }
 
@@ -249,5 +299,25 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
   void setState(_, [callback()]) {
     numberOfRedraws++;
     if (callback != null) callback();
+  }
+}
+
+final TestNested = react.registerComponent(() => new TestNestedComponent());
+class TestNestedComponent extends FluxComponent {
+  int renderCount = 0;
+
+  @override
+  render() {
+    renderCount++;
+
+    var keyCounter = 0;
+    var newChildren = props['children'].map((child) {
+      // The keys are consistent across rerenders, so they aren't remounted,
+      // but cloning the element is necessary for react to consider it changed,
+      // since it returns new ReactElement instances.
+      return cloneElement(child, {'key': keyCounter++});
+    }).toList();
+
+    return react.div({}, newChildren);
   }
 }

--- a/test/component_test.html
+++ b/test/component_test.html
@@ -1,0 +1,28 @@
+<!--
+Copyright 2016 Workiva Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- javascript -->
+    <script src="packages/react/react_with_addons.js"></script>
+    <script src="packages/react/react_dom.js"></script>
+
+    <link rel="x-dart-test" href="component_test.dart">
+    <script src="packages/test/dart.js"></script>
+</head>
+<body></body>
+</html>

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -70,10 +70,13 @@ void main() {
       expect(component.renderCount, equals(0));
     });
 
-    test('should not redraw when didBatchRedraw is true, and should reset it to false afterwards', () async {
+    test(
+        'should not redraw when didBatchRedraw is true,'
+        ' and should reset it to false afterwards', () async {
       component.didBatchRedraw = true;
       component.redraw();
-      expect(component.didBatchRedraw, isTrue, reason: 'should not have been reset yet');
+      expect(component.didBatchRedraw, isTrue,
+          reason: 'should not have been reset yet');
       await nextTick();
       expect(component.renderCount, equals(0));
       expect(component.didBatchRedraw, isFalse);

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -70,6 +70,15 @@ void main() {
       expect(component.renderCount, equals(0));
     });
 
+    test('should not redraw when didBatchRedraw is true, and should reset it to false afterwards', () async {
+      component.didBatchRedraw = true;
+      component.redraw();
+      expect(component.didBatchRedraw, isTrue, reason: 'should not have been reset yet');
+      await nextTick();
+      expect(component.renderCount, equals(0));
+      expect(component.didBatchRedraw, isFalse);
+    });
+
     test(
         'should redraw the component when redraw() is called, when using the callback',
         () async {


### PR DESCRIPTION
## Ultimate Problem
Flux components were rerendered excessively when nested inside each other and a store trigger caused rerendering of those nested components.

See reduced test case [here](https://gist.github.com/greglittlefield-wf/e2cd42b03261e1cb11817a6e5718025d).

## Solution
Track whether components were already redrawn during the current redraw batch.

All consumers will need to do is make sure to call `super.componentDidUpdate` in overrides, and they'll get this fix.

_OverReact PR (`FluxUiComponent`) is available here: https://github.com/Workiva/over_react/pull/103._

## Testing
Verify tests pass.

## Areas of Regression
Flux component rerendering

---

FYA @Workiva/web-platform-pp @Workiva/ui-platform-pp 
FYI: @kylemcmorrow-wf @johnbland-wf @brentschuele-wf @brandonrodgers-wf @robbielamb-wf 