### PR TITLE
WP-4467 Release w_flux 2.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.7.2
+version: 2.8.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4449 Remove rate limit dependency.](https://github.com/Workiva/w_flux/pull/91)
* [WP-4872 fix broken tests and deprecations](https://github.com/Workiva/w_flux/pull/94)
* [RAP-2146 Make store extend Stream](https://github.com/Workiva/w_flux/pull/95)


Requested by: @georgelesica-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.7.2...version-bump-w_flux-2-8-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.7.2...2.8.0