### PR TITLE
WP-4882 Add DDC Tests in CI

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   w_common: ^1.7.0
 dev_dependencies:
   coverage: ^0.7.9
-  dart_dev: ^1.7.7
+  dart_dev: ^1.8.0
   dart_style: '>=0.2.4 <2.0.0'
   dartdoc: '>=0.9.0 <0.13.0'
   over_react: '^1.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   dart_dev: ^1.8.0
   dart_style: '>=0.2.4 <2.0.0'
   dartdoc: '>=0.9.0 <0.13.0'
-  over_react: '^1.0.0'
+  over_react: ^1.13.0
   rxdart: ^0.12.0
   test: ^0.12.15+12
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,3 +27,7 @@ dev_dependencies:
 
 environment:
   sdk: ">=1.21.0 <2.0.0"
+
+transformers:
+  - test/pub_serve:
+      $include: test/**_test{.*,}.dart

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,11 +1,13 @@
 project: dart
 language: dart
 
-# dart 1.22.0, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.9
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:124921
+# This image is created using https://github.com/Workiva/smithy-runner-generator
+#runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: drydock.workiva.net/workiva/smithy-runner-generator:202759 # Dart 1.24.2 w/ stable chrome
 
 script:
   - pub get
+  - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --web-compiler=dartdevc -p chrome -p vm
 
 artifacts:
   build:

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -2,11 +2,10 @@ project: dart
 language: dart
 
 # This image is created using https://github.com/Workiva/smithy-runner-generator
-#runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
-runner_image: drydock.workiva.net/workiva/smithy-runner-generator:202759 # Dart 1.24.2 w/ stable chrome
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:203768 # Dart 1.24.2
 
 script:
-  - pub get
+  - pub get --packages-dir
   - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --web-compiler=dartdevc -p chrome -p vm
 
 artifacts:

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -27,6 +27,7 @@ main(List<String> args) async {
   config.coverage.pubServe = true;
   config.format.paths = dirs;
   config.test.platforms = ['vm', 'content-shell'];
+  config.test.pubServe = true;
 
   await dev(args);
 }


### PR DESCRIPTION
### Descriptions
w_flux is ddc compliant, but future changes could lead to test failures with ddc 

### Changes
Run tests with ddc in smithy!

### QA/Testing
- [ ] CI Passes
- [ ] Examples run when compiling with DDC
  - [ ] Serve examples using `pub serve example --web-compiler=dartdevc`, then navigate to localhost:8080 in chrome

@Workiva/web-platform-pp 