### PR TITLE
WP-4923 Stop using the deprecated stream

### DIFF
--- a/lib/src/component_common.dart
+++ b/lib/src/component_common.dart
@@ -66,7 +66,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
             value: (_) => (_) => redraw())
           ..addAll(getStoreHandlers());
     handlers.forEach((store, handler) {
-      listenToStream(store.stream, handler);
+      listenToStream(store, handler);
     });
   }
 


### PR DESCRIPTION
This was causing two problems:

1. If store is a mock this fails due to an argument error unless the mock is configured to return a stream for store.stream
2. stream is deprecated and should not be used, plus it is only visible for testing. 

With this, a mocked store now needs to stub listen rather than stream.