### PR TITLE
WP-4915 Release w_flux 2.9.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.8.0
+version: 2.9.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4924 Redraw only once when store triggers along with ancestor rerender](https://github.com/Workiva/w_flux/pull/96)
* [WP-4923 Stop using the deprecated stream](https://github.com/Workiva/w_flux/pull/100)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.8.0...version-bump-w_flux-2-9-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.8.0...2.9.0