### PR TITLE
WP-4937 Fix case where setState and store trigger only result in one render

### DIFF
--- a/lib/src/component_client.dart
+++ b/lib/src/component_client.dart
@@ -38,9 +38,9 @@ abstract class FluxComponent<ActionsT, StoresT>
 
   @mustCallSuper
   @override
-  void componentDidUpdate(Map prevProps, Map prevState) {
-    // Let BatchedRedraws know that this component has redrawn in the current batch
+  void componentWillReceiveProps(Map prevProps) {
+    // Let BatchedRedraws know that this component is redrawing in the current batch
     didBatchRedraw = true;
-    super.componentDidUpdate(prevProps, prevState);
+    super.componentWillReceiveProps(prevProps);
   }
 }

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -246,6 +246,31 @@ void main() {
           reason: 'should have rerendered once in response to'
               ' the store triggering');
     });
+
+    test(
+        'redraws twice in response to a component calling setState'
+        ' and a store trigger happening at the same time', () async {
+      var store = new Store();
+
+      TestNestedComponent nested0;
+
+      react_test_utils.renderIntoDocument((TestNested({
+        'store': store,
+        'ref': (ref) {
+          nested0 = ref;
+        },
+      })));
+      expect(nested0.renderCount, 1, reason: 'setup check: initial render');
+
+      nested0.setState({});
+      store.trigger();
+      await animationFrames(2);
+
+      expect(nested0.renderCount, 3,
+          reason: 'should have rerendered once in response to'
+              ' the store triggering'
+              ' and once in response to setState');
+    });
   });
 }
 


### PR DESCRIPTION
## Ultimate problem:
Currently, when a component calls `setState` at the same time the store triggers, the rerender with the updated store does not take place.

## How it was fixed:
Use `componentWillReceiveProps` to mark batch redraws instead of `componentDidUpdate`.

This will mark only components that are getting excessive rerenders from parent components, and not components that have unrelated `setState` calls.

___Also fixed in over_react: https://github.com/Workiva/over_react/pull/108___

## Testing suggestions:
- Verify tests pass

## Potential areas of regression:
FluxUiComponent batch redrawing.

---

FYA: @Workiva/ui-platform-pp @Workiva/web-platform-pp 
