### PR TITLE
WP-4925 Release w_flux 2.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,33 @@
 language: dart
+sudo: required
 dart:
-  - 1.22.1
-with_content_shell: true
+  - 1.24.2
+addons:
+  apt:
+    packages:
+    - ttf-kochi-mincho
+    - ttf-kochi-gothic
+    - ttf-dejavu
+    - ttf-indic-fonts
+    - fonts-tlwg-garuda
 before_install:
+  # Content shell needs this font. Since it has a EULA, we need to manually
+  # install it.
+  #
+  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
+  # fixed.
+  - sudo apt-get update -yq
+  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+  - sudo apt-get install msttcorefonts -qq
+
+  - mkdir -p bin
+  - export PATH="$PATH:`pwd`/bin/"
+  - ln -s `which chromium-browser` bin/google-chrome
+
+  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
+  - unzip content_shell-linux-x64-release.zip
+  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
+
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3 # give xvfb some time to start

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.9.0
+version: 2.9.1
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4937 Fix case where setState and store trigger only result in one render](https://github.com/Workiva/w_flux/pull/105)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.9.0...version-bump-w_flux-2-9-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.9.0...2.9.1