### PR TITLE
WP-5043 Improve store state error messages

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -94,7 +94,7 @@ class Store extends Stream<Store> with Disposable {
   StreamSubscription<Store> listen(StoreHandler onData,
       {Function onError, void onDone(), bool cancelOnError}) {
     if (isDisposed) {
-      throw new StateError('Store has been disposed');
+      throw new StateError('Store of type $runtimeType has been disposed');
     }
 
     return _stream.listen(onData,
@@ -137,7 +137,7 @@ class Store extends Stream<Store> with Disposable {
   /// If the `Store` has been disposed, this method throws a [StateError].
   triggerOnAction(Action action, [void onAction(payload)]) {
     if (isDisposed) {
-      throw new StateError('Store has been disposed');
+      throw new StateError('Store of type $runtimeType has been disposed');
     }
     manageActionSubscription(action.listen((payload) async {
       if (onAction != null) {


### PR DESCRIPTION
## Problem

The message associated with the `StateError` that is thrown when an action subscription is managed or when the store is listened to after disposal is cryptic.

## Solution

Add the `runtimeType` to help the situation a bit.

## Potential Regressions

None.

## Tests

Existing tests are sufficient, the new error message is an ergonomic issue.

## QA / +10

1. CI passes

## FYI

@seanburke-wf 