### PR TITLE
WP-5242 Widen react-dart range to include memory leak fix in 4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ homepage: https://github.com/Workiva/w_flux
 
 dependencies:
   meta: ^1.0.4
-  react: ^3.0.0
+  react: '>=3.0.0 <5.0.0'
   w_common: ^1.7.0
 dev_dependencies:
   coverage: ^0.7.9


### PR DESCRIPTION
## Dependency, config, and/or RM change callouts
Widen react-dart dependency to include 4.0.0.

## Problem
react-dart 4.0.0 includes improvements to Dart component instance management that help avoid certain memory leaks. See more info here: https://github.com/cleandart/react-dart/pull/127.

While this release contains breaking changes, those breakages are limited to internals that should be smoothed over by over_react, and should not affect the majority of consumers.

## Solution
Widen react-dart version range to include 4.0.0.

Once this range has been widened throughout the Workiva's dependency tree, everyone should get 4.0.0 for free.

## Test Overview (+10 Instructions)
- [ ] Verify that `pub get` still resolves properly in the build, and react-dart 4.0.0 is pulled in
- [ ] Verify that tests pass

## Semantic Versioning
**Patch**
- [x] This change does not affect the public API

## Areas of Regression
React component rendering/testing
