### PR TITLE
WP-5044 Release w_flux 2.9.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.9.3
+version: 2.9.4
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [WP-5242 Widen react-dart range to include memory leak fix in 4.0.0](https://github.com/Workiva/w_flux/pull/111)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.9.3...Workiva:release_w_flux_2_9_4
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.9.3...2.9.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6058676244709376/logs/)