### PR TITLE
af_new_drydock_image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:203768 as build
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:355624 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -2,7 +2,7 @@ project: dart
 language: dart
 
 # This image is created using https://github.com/Workiva/smithy-runner-generator
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:203768 # Dart 1.24.2
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:355624
 
 script:
   - pub get --packages-dir


### PR DESCRIPTION
## Purpose

The following pull request has been created by App Frameworks to help move consumers to the latest Smithy image. This was done because of an issue with Dartium and Content-Shell that would fail your CIs. Please seethis [Wiki Question](https://wiki.atl.workiva.net/cq/viewquestion.action?id=96308901&answerId=96308907)for additional context.

## Changes

The following changes have been made:
* All instances of the production Smithy image have been updated to `drydock-prod.workiva.net/workiva/smithy-runner-generator:355624`.

## Questions

If you have any questions, please reach out to us in the Support:H5 / Dart Hipchat room