### PR TITLE
AF-2888 Accommodate tracing of Store triggers and resulting redraws

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: dart
 dart:
-  - stable
-  - dev
+  - 1.24.3
 sudo: required
 addons:
   chrome: stable


### PR DESCRIPTION
### Ultimate Problem
To implement tracing of Flux components in https://github.com/Workiva/app_intelligence_dart/pull/737, we needed a way to:
- know whether a call to `redraw` was triggered from a store handler, and know which store triggered the redraw
- set up a custom default handler for certain types of stores

### Solution
- Add lifecycle methods to allow subclasses to safely hook into and override store redraw logic:
    - `listenToStoreForRedraw`
        - See example override [here](https://github.com/Workiva/app_intelligence_dart/blob/7714bd160f7d735b32a7e4beaa9e49bab8f2a6b9/lib/src/app_data_types/tracing/w_flux/traced_flux_component.dart#L150)
    - `handleRedrawOn`
        - See exampleoverride [here](https://github.com/Workiva/app_intelligence_dart/blob/7714bd160f7d735b32a7e4beaa9e49bab8f2a6b9/lib/src/app_data_types/tracing/w_flux/traced_flux_component.dart#L152-L159)
- Add Tests

### Testing
- Verify tests pass
- Smoke test examples

---

@dustinlessard-wf @kealjones-wk @evanweible-wf 
@aaronlademann-wf @kealjones-wk 