### PR TITLE
CPLAT-2948 Release w_flux 2.10.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.10.1
+version: 2.10.2
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-3300: CP Code Review and PR Merging Team agreement update](https://github.com/Workiva/w_flux/pull/126)
	* [Fix http -> https](https://github.com/Workiva/w_flux/pull/127)
	* [CPLAT-6767 Bump build dep ranges to fix build in master](https://github.com/Workiva/w_flux/pull/129)


Requested by: @smaifullerton-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.6.0...Workiva:release_w_flux_2.10.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.6.0...2.10.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6058676244709376/logs/)