### PR TITLE
CPLAT-6850: Add disposable type name(s)

### DIFF
--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -46,6 +46,9 @@ import 'package:w_flux/src/constants.dart' show v3Deprecation;
 /// action.
 ///
 class Action<T> extends Object with Disposable implements Function {
+  @override
+  String get disposableTypeName => 'Action';
+
   List _listeners = [];
 
   /// Dispatch this [Action] to all listeners. If a payload is supplied, it will

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -40,6 +40,9 @@ typedef StoreHandler(Store event);
 /// `Store`s, triggering re-rendering of the UI elements based on the updated
 /// `Store` data.
 class Store extends Stream<Store> with Disposable {
+  @override
+  String get disposableTypeName => 'Store';
+
   /// Stream controller for [_stream]. Used by [trigger].
   final StreamController<Store> _streamController;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 dev_dependencies:
   build_runner: ">=0.6.0 <2.0.0"
   build_test: ">=0.9.0 <2.0.0"
-  build_web_compilers: ">=0.2.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^2.0.0
   dart_style: ^1.0.9


### PR DESCRIPTION
Some of the classes that extend or mixin `Disposable` missing `disposableTypeName` override.
     This PR will add missing overrides, where it's necessary