### PR TITLE
RM-55910 Release w_flux 2.10.4

### DIFF
--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -18,6 +18,7 @@ import 'dart:html';
 import 'dart:math';
 
 import 'package:react/react.dart' as react;
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
@@ -30,7 +31,9 @@ main() async {
 
   // render the component
   react_client.setClientConfiguration();
-  react_dom.render(RandomColorComponent({'actions': actions, 'store': store}),
+  react_dom.render(
+      ErrorBoundary()(
+          RandomColorComponent({'actions': actions, 'store': store})),
       querySelector('#content-container'));
 }
 

--- a/example/todo_app/todo_app.dart
+++ b/example/todo_app/todo_app.dart
@@ -16,6 +16,7 @@ library w_flux.example.todo_app;
 
 import 'dart:html';
 
+import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
@@ -30,6 +31,7 @@ main() async {
 
   // render the component
   react_client.setClientConfiguration();
-  react_dom.render(ToDoAppComponent({'actions': actions, 'store': store}),
+  react_dom.render(
+      ErrorBoundary()(ToDoAppComponent({'actions': actions, 'store': store})),
       querySelector('#content-container'));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.10.3
+version: 2.10.4
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's flux architecture.
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   meta: ^1.0.4
-  react: ">=3.0.0 <6.0.0"
+  react: ">=4.7.0 <6.0.0"
   w_common: ^1.9.0
 
 dev_dependencies:
@@ -25,6 +25,7 @@ dev_dependencies:
   coverage: ">=0.10.0 <0.13.0"
   dart_dev: ^2.0.0
   dart_style: ^1.0.9
+  over_react: ">=2.4.0 <4.0.0"
   test: ">=0.12.30 <2.0.0"
 
 transformers:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   meta: ^1.0.4
-  react: ">=3.0.0 <5.0.0"
+  react: ">=3.0.0 <6.0.0"
   w_common: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
This release opens the upper-bound of the react dependency to allow 5.x releases.

### QA

- [ ] Passing CI
- [ ] Passing CI for #134