### PR TITLE
CPLAT-8207: Cleanup React 16 Transition

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,3 +1,2 @@
 platforms:
   - chrome
-  - vm

--- a/example/todo_app/components/new_todo_input.dart
+++ b/example/todo_app/components/new_todo_input.dart
@@ -18,11 +18,11 @@ import 'package:react/react.dart' as react;
 
 var NewTodoInput = react.registerComponent(() => _NewTodoInput());
 
-class _NewTodoInput extends react.Component {
+class _NewTodoInput extends react.Component2 {
   String get value => state['value'];
   Function get onSubmit => props['onSubmit'];
 
-  getInitialState() => {'value': ''};
+  get initialState => {'value': ''};
 
   render() {
     return react.form(

--- a/example/todo_app/components/todo_list_item.dart
+++ b/example/todo_app/components/todo_list_item.dart
@@ -20,11 +20,11 @@ import '../store.dart';
 
 var TodoListItem = react.registerComponent(() => _TodoListItem());
 
-class _TodoListItem extends react.Component {
+class _TodoListItem extends react.Component2 {
   Todo get todo => props['todo'];
   Function get onClick => props['onClick'];
 
-  getDefaultProps() => {'todo': null};
+  get defaultProps => {'todo': null};
 
   render() {
     String className =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
     meta: ^1.1.7
-    react: ">=4.7.0 <6.0.0"
+    react: ^5.1.0
     w_common: ^1.20.1
 
 dev_dependencies:
@@ -26,5 +26,5 @@ dev_dependencies:
     build_vm_compilers: ^1.0.3
     dart_dev: ^3.0.0
     dart_style: ^1.3.1
-    over_react: ">=2.5.0 <4.0.0"
+    over_react: ^3.1.3
     test: ^1.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dev_dependencies:
     build_runner: ^1.7.1
     build_test: ^0.10.9
     build_web_compilers: ^2.5.1
-    build_vm_compilers: ^1.0.3
     dart_dev: ^3.0.0
     dart_style: ^1.3.1
     over_react: ^3.1.3

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn('vm')
+@TestOn('browser')
 library w_flux.test.action_test;
 
 import 'dart:async';

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn('vm')
+@TestOn('browser')
 library w_flux.test.component_server_test;
 
 import 'dart:async';

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn('vm')
+@TestOn('browser')
 library w_flux.test.store_test;
 
 import 'dart:async';


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__
>
> Repo owners will be notified when it is ready for additional review, merge and release.

## Motivation
Now that React 16 is part of Production Wdesk we are coming back through to clean up the transitional comments, and dependency ranges.

We're also taking this opportunity to give you a head start on consuming Component2 / UiComponent2!

> __For more details, see [the Component2 Wiki](https://wiki.atl.workiva.net/display/CP/What%27s+new+in+Component2).__

To summarize Component2 changes:

###### Pros:
- Supports new lifecycle methods, allowing us to use Concurrent Mode in the future
- Slightly faster
- Improved dev experience
    - Props/state show up in the React DevTools, and primitive values (strings, numbers, booleans) can be edited live, just like in React JS!
![React DevTools with Component2](https://user-images.githubusercontent.com/1750797/68478015-1259b500-01ec-11ea-92bf-0bd432cd4001.gif)

###### Cons:
- Breaks a few advanced component lifecycle methods and APIs. Some of them can be upgraded automatically via a codemod, others will require manual conversion.
    - Migration to these new classes is not currently required, and can happen at any time.
- Old base classes (Component/UiComponent/etc.) are deprecated.

## Changes
1. Update lower bounds of react and over_react.
2. Remove transitional comments.
3. Upgrade components that are able to be automatically fully upgraded to UiComponent2.
  - This step is done as a 2nd commit in order to ease reverting the change if needed.
  - Consumers can upgrade the rest of their components at a later time by running:
    - `pub global activate over_react_codemod`, followed by:
    - `pub global run over_react_codemod:component2_upgrade` (to get the partial upgrades)
        - Then, manually migrate to the new lifecycle methods (see doc comments and wiki for more info).
    - `pub global run over_react_codemod:component2_upgrade --abstract` (to upgrade abstract components that need to be manually verified)
        - Then, manually verify that abstract components aren't exported to avoid breaking consumers.

## Review
__Please review, QA and merge:__ <tag repo owners / contributors here>

### QA Checklist
- [ ] Passing CI
- [ ] Verify all `FIXME` comments added by codemod have been addressed/removed.
- [ ] Verify/smokecheck that Components upgraded to UiComponent2 are still functioning as expected.

#### Release Notes
- Cleanup from React 16 transition.
- Upgrade eligible Components to Component2.

> [More information about React 16 and UiComponent2](https://wiki.atl.workiva.net/pages/viewpage.action?spaceKey=CP&title=What%27s+new+in+Component2)
