### PR TITLE
Prevent BatchedRedraws from holding up the thread

### DIFF
--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -21,31 +21,31 @@ class _RedrawScheduler implements Function {
   }
 
   Future _tick() async {
-      await window.animationFrame;
+    await window.animationFrame;
 
-      var entries = _components.entries.toList();
-      _components.clear();
-      for (var entry in entries) {
-        var component = entry.key;
-        var callbacks = entry.value;
-          // Skip if the component doesn't want to batch redraw
-          if (!component.shouldBatchRedraw) {
-            continue;
-          }
-
-          Function() chainedCallbacks;
-          await Future.delayed(const Duration(milliseconds: 0));
-          if (callbacks.isNotEmpty) {
-            chainedCallbacks = () {
-              callbacks.forEach((callback) {
-                callback();
-              });
-            };
-          }
-
-          (component as react.Component)?.setState({}, chainedCallbacks);
+    var entries = _components.entries.toList();
+    _components.clear();
+    for (var entry in entries) {
+      var component = entry.key;
+      var callbacks = entry.value;
+      // Skip if the component doesn't want to batch redraw
+      if (!component.shouldBatchRedraw) {
+        continue;
       }
+
+      Function() chainedCallbacks;
+      await Future.delayed(const Duration(milliseconds: 0));
+      if (callbacks.isNotEmpty) {
+        chainedCallbacks = () {
+          callbacks.forEach((callback) {
+            callback();
+          });
+        };
+      }
+
+      (component as react.Component)?.setState({}, chainedCallbacks);
     }
+  }
 }
 
 _RedrawScheduler _scheduleRedraw = _RedrawScheduler();

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -6,7 +6,8 @@ import 'dart:html';
 import 'package:react/react.dart' as react;
 
 class _RedrawScheduler implements Function {
-  Map<BatchedRedraws, List<Function>> _components = <BatchedRedraws, List<Function>>{};
+  Map<BatchedRedraws, List<Function>> _components =
+      <BatchedRedraws, List<Function>>{};
 
   void call(BatchedRedraws component, [callback()]) {
     if (_components.isEmpty) {

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -33,7 +33,7 @@ class _RedrawScheduler implements Function {
             continue;
           }
 
-          var chainedCallbacks;
+          Function() chainedCallbacks;
           await Future.delayed(const Duration(milliseconds: 0));
           if (callbacks.isNotEmpty) {
             chainedCallbacks = () {

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -34,7 +34,6 @@ class _RedrawScheduler implements Function {
       }
 
       Function() chainedCallbacks;
-      await Future.delayed(const Duration(milliseconds: 0));
       if (callbacks.isNotEmpty) {
         chainedCallbacks = () {
           callbacks.forEach((callback) {
@@ -44,6 +43,8 @@ class _RedrawScheduler implements Function {
       }
 
       (component as react.Component)?.setState({}, chainedCallbacks);
+
+      await Future.delayed(const Duration(milliseconds: 0));
     }
   }
 }

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -2,13 +2,11 @@ library w_flux.mixins.batched_redraws;
 
 import 'dart:async';
 import 'dart:html';
-import 'dart:js' as js;
 
 import 'package:react/react.dart' as react;
 
 class _RedrawScheduler implements Function {
-  Map<BatchedRedraws, List<Function>> _components =
-      <BatchedRedraws, List<Function>>{};
+  Map<BatchedRedraws, List<Function>> _components = <BatchedRedraws, List<Function>>{};
 
   void call(BatchedRedraws component, [callback()]) {
     if (_components.isEmpty) {
@@ -34,6 +32,7 @@ class _RedrawScheduler implements Function {
       }
 
       Function() chainedCallbacks;
+
       if (callbacks.isNotEmpty) {
         chainedCallbacks = () {
           callbacks.forEach((callback) {
@@ -43,7 +42,6 @@ class _RedrawScheduler implements Function {
       }
 
       (component as react.Component)?.setState({}, chainedCallbacks);
-
       await Future.delayed(const Duration(milliseconds: 0));
     }
   }

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -22,6 +22,7 @@ class _RedrawScheduler implements Function {
   Future _tick() async {
     await window.animationFrame;
 
+    // Making a copy of `_components` so we don't iterate over the map while it's potentially being mutated.
     var entries = _components.entries.toList();
     _components.clear();
     for (var entry in entries) {
@@ -43,7 +44,9 @@ class _RedrawScheduler implements Function {
       }
 
       (component as react.Component)?.setState({}, chainedCallbacks);
-      await Future.delayed(const Duration(milliseconds: 0));
+
+      // Waits a tick to prevent holding up the thread, allowing other scripts to execute in between each component.
+      await Future(() {});
     }
   }
 }


### PR DESCRIPTION
_**Featuring @greglittlefield-wf as co-author!**_ 

## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
While checking the performance of componentry in a consuming repo, it was noticed that occasionally batched updates would hold up the thread preventing anything else from executing. This becomes problematic for things like data fetching. If the batch redraw starts after a data request is sent the response cannot be handled until batch redraws finishes, and if these batched redraws take a lot of time (lots of components to update) it will push checking/handling the data fetching response until it finishes, Making data fetching artificially take longer.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Add a tick between each redraw.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#manual-testing-criteria
