### PR TITLE
Release w_flux 2.11.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.10.9
+version: 2.11.0
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's
     flux architecture.
 authors:


### PR DESCRIPTION


Requested by: @joebingham-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.10.9...Workiva:release_w_flux_2.11.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.10.9...2.11.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6058676244709376/logs/)