### PR TITLE
Test React 17 Update

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,4 +36,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: react-17-no-event-wrappers
+      ref: 6.0.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,8 +32,8 @@ dependency_overrides:
   over_react:
     git:
       url: https://github.com/Workiva/over_react.git
-      ref: react-17-synthetic-event-updates
+      ref: 4.0.0-wip
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 6.0.0-wip
+      ref: test-proptypes-in-getDerivedStateFromProps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,3 +27,13 @@ dev_dependencies:
     dart_style: ^1.3.1
     over_react: ^3.1.3
     test: ^1.9.1
+
+dependency_overrides:
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: 4.0.0-wip
+  react:
+    git:
+      url: https://github.com/cleandart/react-dart.git
+      ref: testing-react-17-rc

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,8 +32,8 @@ dependency_overrides:
   over_react:
     git:
       url: https://github.com/Workiva/over_react.git
-      ref: 4.0.0-wip
+      ref: react-17-synthetic-event-updates
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: testing-react-17-rc
+      ref: react-17-no-event-wrappers


### PR DESCRIPTION
This PR tests CI with React 17 dependencies (`over_react` v4.0.0 and `react-dart` v6.0.0). Do not merge.