### PR TITLE
Delete docs.yml file created for Dev Portal.

### DIFF
--- a/docs.yml
+++ b/docs.yml
@@ -1,3 +1,0 @@
-title: w_flux
-base: github:Workiva/w_flux/
-src: README.md


### PR DESCRIPTION
https://jira.atl.workiva.net/browse/DE-552

As part of, 
[Dev Portal Service deprecation](https://wiki.atl.workiva.net/display/DE/Poster+-+Dev+Portal+Discovery+2.0%3A+Discovery+and+Planning); 
we are deprecating the “docs.yml” file that’s been created to render repo markdown files on to the portal.

File paths included in docs.yml of this repo will no longer be rendered/hosted on
[Dev Portal](https://dev.workiva.net/docs/) with the yml file deletion.

Please reach out to `#support-dev-portal` or `#support-developer-efficiency` with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_docs_yml`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_docs_yml)