### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/example/random_color/random_color.dart
+++ b/example/random_color/random_color.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/example/todo_app/todo_app.dart
+++ b/example/todo_app/todo_app.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)