### PR TITLE
Raise Max Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.15
+
+- Dependency upgrades
+
 ## 2.1.0
 Support for react-dart 0.9.x (which moves to ReactJS 0.14)
 
@@ -40,7 +44,7 @@ Check out the detailed [release notes](//github.com/Workiva/w_flux/releases/tag/
 
 ## 0.2.0
 - Shorter action dispatch
-- Add triggerOnAction to store 
+- Add triggerOnAction to store
 - Support throttling of store triggers
 - Allow react-dart 0.7.x releases
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     w_common: ^1.20.1
 
 dev_dependencies:
-    build_runner: ^1.7.1
+    build_runner: '>=1.7.1 <3.0.0'
     build_test: ">=0.10.9 <2.0.0"
     build_web_compilers: ^2.5.1
     dart_dev: ^3.0.0


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)