### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 
 WORKDIR /build
 ADD pubspec.* /build/
-RUN pub get
+RUN dart pub get
 
 FROM scratch

--- a/example/README.md
+++ b/example/README.md
@@ -3,5 +3,5 @@ w_flux Examples
 
 To run the examples, open the root of this repository in a command-line terminal.
 
-1. `pub run dart_dev examples`
+1. `dart run dart_dev examples`
 2. Open Chromium/Dartium to `http://localhost:8080`


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)