### PR TITLE
FW-58 Add skynet run that checks that github workflow run passes

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,20 +1,13 @@
 name: verify-github-actions
 description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
 contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/skynet-images:3708893 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+image: drydock.workiva.net/workiva/skynet-images:3728345 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
 size: small
 timeout: 600
-
-run:
-  on-pull-request: false
-  on-promotion: true
-  when-modified-file-name-is: 
-    - skynet.yaml
 
 env:
 # encrypted github token used for requests to api.github.com
  - secure: DndqTHp2eL5UlnC6kxDgKZsXGO1qUCIfcGErhm4IVOQtX/OxNax31XMlgJusfpD0XbQih5zo7H3XwiFPafc4In/Zi0E=
-
 
 scripts:
   - python3 /actions/verify_github_actions.py

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,13 +1,14 @@
-name: w_flux-unit-tests
-description: Unit tests
+name: verify-github-actions
+description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
 contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/dart_unit_test_image:1
+image: drydock.workiva.net/workiva/skynet-images:pr-127
 size: small
-timeout: short
+timeout: 600
 
-run:
-  on-tag: true
-  on-pull-request: true
+env:
+# encrypted github token used for requests to api.github.com
+ - secure: DndqTHp2eL5UlnC6kxDgKZsXGO1qUCIfcGErhm4IVOQtX/OxNax31XMlgJusfpD0XbQih5zo7H3XwiFPafc4In/Zi0E=
+
 
 scripts:
-  - echo "Tests run in github workflows"
+  - python3 /actions/verify_github_actions.py

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -5,6 +5,12 @@ image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from t
 size: small
 timeout: 600
 
+run:
+  on-pull-request: false
+  on-promotion: true
+  when-modified-file-name-is: 
+    - skynet.yaml
+
 env:
 # encrypted github token used for requests to api.github.com
  - secure: DndqTHp2eL5UlnC6kxDgKZsXGO1qUCIfcGErhm4IVOQtX/OxNax31XMlgJusfpD0XbQih5zo7H3XwiFPafc4In/Zi0E=

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,7 +1,7 @@
 name: verify-github-actions
 description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
 contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/skynet-images:pr-127
+image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
 size: small
 timeout: 600
 


### PR DESCRIPTION
## Motivation
Currently release pipelines are failing because they require a skynet run in order to pass the testing phase of the pipeline. We would like to not have to manually check that the github workflow passed and override the pipeline so we need a way to automatically check that the workflow passed and tell the pipeline that all is good.
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
Add a skynet.yaml that checks the github workflow run and passes or fails the skynet run depending on the results.
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
Add skynet run to check that the github workflow run passes  
<!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#manual-testing-criteria
