### PR TITLE
Test Dart 2.18

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, beta ]
+        sdk: [ 2.13.4, 2.18.7 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -42,18 +42,6 @@ jobs:
         run: dart run dart_dev test --release
         if: always() && steps.install.outcome == 'success'
 
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.2
-        with:
-          sdk: 2.13.4
-
-      - id: install
-        name: Install dependencies
-        run: dart pub get
-
       - name: Verify formatting
-        run: dart run dart_dev format --check
+        run: dart format --set-exit-if-changed .
         if: always() && steps.install.outcome == 'success'

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, beta, dev ]
+        sdk: [ 2.13.4, stable, beta ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -31,7 +31,7 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 
       - name: Analyze project source
-        run: dart run dart_dev analyze
+        run: dart analyze
         if: always() && steps.install.outcome == 'success'
 
       - name: Run tests with ddc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7
 
 WORKDIR /build
 ADD pubspec.* /build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 
 WORKDIR /build
 ADD pubspec.* /build/

--- a/dart_dependency_validator.yaml
+++ b/dart_dependency_validator.yaml
@@ -1,0 +1,3 @@
+ignore:
+  # Ignore the pin on the test package while we have to avoid a bad version of test 1.18.1 https://github.com/dart-lang/test/issues/1620
+  - test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   dart_style: ^2.1.1
   dependency_validator: ^3.0.0
   over_react: ">=3.12.0 <5.0.0"
-  test: ^1.15.7
+  test: ">=1.15.7 <1.18.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,5 @@ dev_dependencies:
   dart_style: ^2.1.1
   dependency_validator: ^3.0.0
   over_react: ">=3.12.0 <5.0.0"
-  test: ">=1.15.7 <1.18.0"
+  # Avoid a bad version of test 1.18.1 https://github.com/dart-lang/test/issues/1620
+  test: ">=1.15.7 <1.18.1" 


### PR DESCRIPTION
Summary
---
This batch overrides the docker images used to equivalent Dart 2.18 versions.
The goal is to run as many CI runs across the dart ecosystem as possible on 
Dart 2.18 to find and fix errors before releasing a production 2.18 image.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_dart_218`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_dart_218)