### PR TITLE
Prepare for dart_dev v4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   build_test: ^2.1.3
   build_vm_compilers: ^1.0.11
   build_web_compilers: ^3.0.0
-  dart_dev: ^3.8.5
+  dart_dev: '>=3.8.5 <5.0.0'
   dart_style: ^2.1.1
   dependency_validator: ^3.0.0
   over_react: ">=3.12.0 <5.0.0"


### PR DESCRIPTION
This PR widens the allowable version ranges of dart_dev so that all repos at Workiva can consume dart_dev 4.0.0 without updating all repositories in lock step.
For more info, reach out to Timothy Steward or `#link23-state-of-the-dart-jam` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dev_widen_ranges_v4`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dev_widen_ranges_v4)