### PR TITLE
RM-188016 Release w_flux 2.10.25

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w_flux
-version: 2.10.24
+version: 2.10.25
 description: Flux library for uni-directional dataflow inspired by reflux and Facebook's
     flux architecture.
 homepage: https://github.com/Workiva/w_flux


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Make example a separate pkg to remove over_react](https://github.com/Workiva/w_flux/pull/179)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_flux/compare/2.10.24...Workiva:release_w_flux_2.10.25
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_flux/compare/2.10.24...2.10.25

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6058676244709376/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6058676244709376/?repo_name=Workiva%2Fw_flux&pull_number=180)