### PR TITLE
Null safety, Add Action2

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,7 +8,7 @@ analyzer:
     # When compiling to JS, both implicit options apply to the current 
     # project and all dependencies. They are useful to find possible 
     # Type fixes or areas for explicit typing.
-    implicit-casts: true
+    implicit-casts: false
     implicit-dynamic: true
 
 # ALL lint rules are included. Unused lints should be commented

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,12 @@
+# This analysis_options.yaml is needed so that the Dart analyzer doesn't use the parent directory's analysis_options.yaml,
+# which excludes this example directory.
+
+# analysis_options.yaml docs: https://www.dartlang.org/guides/language/analysis-options
+analyzer:
+  # Strong mode is required. Applies to the current project.
+  strong-mode:
+    # When compiling to JS, both implicit options apply to the current 
+    # project and all dependencies. They are useful to find possible 
+    # Type fixes or areas for explicit typing.
+    implicit-casts: false
+    implicit-dynamic: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: Flux library for uni-directional dataflow inspired by reflux and Fa
 homepage: https://github.com/Workiva/w_flux
 publish_to: none
 environment:
-    sdk: ">=2.11.0 <3.0.0"
+    sdk: '>=2.12.0 <3.0.0'
 dependencies:
   w_flux: 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,3 +21,7 @@ dev_dependencies:
 dependency_overrides:
   w_flux:
     path: ../
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: null-safety-manual-2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,6 @@ publish_to: none
 environment:
     sdk: ">=2.11.0 <3.0.0"
 dependencies:
-  over_react: ">=3.12.0 <5.0.0"
   w_flux: 
 
 dev_dependencies:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,4 +24,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/Workiva/react-dart.git
-      ref: null-safety-manual-2
+      ref: v7_wip

--- a/example/web/random_color/random_color.dart
+++ b/example/web/random_color/random_color.dart
@@ -30,8 +30,7 @@ main() async {
 
   // render the component
   react_client.setClientConfiguration();
-  react_dom.render(
-      RandomColorComponent({'actions': actions, 'store': store}),
+  react_dom.render(RandomColorComponent({'actions': actions, 'store': store}),
       querySelector('#content-container'));
 }
 

--- a/example/web/random_color/random_color.dart
+++ b/example/web/random_color/random_color.dart
@@ -36,7 +36,7 @@ main() async {
 }
 
 class RandomColorActions {
-  final Action changeBackgroundColor = Action();
+  final Action2 changeBackgroundColor = Action2();
 }
 
 class RandomColorStore extends Store {
@@ -74,7 +74,7 @@ class _RandomColorComponent
       'This module uses a flux pattern to change its background color.',
       react.button({
         'style': {'padding': '10px', 'margin': '10px'},
-        'onClick': (_) => actions.changeBackgroundColor()
+        'onClick': (_) => actions.changeBackgroundColor(null)
       }, 'Change Background Color')
     ]);
   }

--- a/example/web/random_color/random_color.dart
+++ b/example/web/random_color/random_color.dart
@@ -18,7 +18,6 @@ import 'dart:html';
 import 'dart:math';
 
 import 'package:react/react.dart' as react;
-import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
@@ -32,8 +31,7 @@ main() async {
   // render the component
   react_client.setClientConfiguration();
   react_dom.render(
-      ErrorBoundary()(
-          RandomColorComponent({'actions': actions, 'store': store})),
+      RandomColorComponent({'actions': actions, 'store': store}),
       querySelector('#content-container'));
 }
 

--- a/example/web/todo_app/actions.dart
+++ b/example/web/todo_app/actions.dart
@@ -19,8 +19,8 @@ import 'package:w_flux/w_flux.dart';
 import 'store.dart';
 
 class ToDoActions {
-  final Action<Todo> createTodo = Action<Todo>();
-  final Action<Todo> completeTodo = Action<Todo>();
-  final Action<Todo> deleteTodo = Action<Todo>();
-  final Action clearTodoList = Action<Todo>();
+  final Action2<Todo> createTodo = Action2<Todo>();
+  final Action2<Todo> completeTodo = Action2<Todo>();
+  final Action2<Todo> deleteTodo = Action2<Todo>();
+  final Action2 clearTodoList = Action2<Todo>();
 }

--- a/example/web/todo_app/components/new_todo_input.dart
+++ b/example/web/todo_app/components/new_todo_input.dart
@@ -19,8 +19,8 @@ import 'package:react/react.dart' as react;
 var NewTodoInput = react.registerComponent(() => _NewTodoInput());
 
 class _NewTodoInput extends react.Component2 {
-  String get value => state['value'] as String;
-  Function get onSubmit => props['onSubmit'] as Function;
+  String get value => state['value'] as String/*!*/;
+  Function get onSubmit => props['onSubmit'] as Function/*!*/;
 
   get initialState => {'value': ''};
 

--- a/example/web/todo_app/components/new_todo_input.dart
+++ b/example/web/todo_app/components/new_todo_input.dart
@@ -1,4 +1,4 @@
- // Copyright 2015 Workiva Inc.
+// Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/example/web/todo_app/components/new_todo_input.dart
+++ b/example/web/todo_app/components/new_todo_input.dart
@@ -19,8 +19,8 @@ import 'package:react/react.dart' as react;
 var NewTodoInput = react.registerComponent(() => _NewTodoInput());
 
 class _NewTodoInput extends react.Component2 {
-  String get value => state['value'];
-  Function get onSubmit => props['onSubmit'];
+  String get value => state['value'] as String;
+  Function get onSubmit => props['onSubmit'] as Function;
 
   get initialState => {'value': ''};
 

--- a/example/web/todo_app/components/new_todo_input.dart
+++ b/example/web/todo_app/components/new_todo_input.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+ // Copyright 2015 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import 'package:react/react.dart' as react;
 var NewTodoInput = react.registerComponent(() => _NewTodoInput());
 
 class _NewTodoInput extends react.Component2 {
-  String get value => state['value'] as String/*!*/;
-  Function get onSubmit => props['onSubmit'] as Function/*!*/;
+  String get value => state['value'] as String;
+  Function get onSubmit => props['onSubmit'] as Function;
 
   get initialState => {'value': ''};
 

--- a/example/web/todo_app/components/todo_app_component.dart
+++ b/example/web/todo_app/components/todo_app_component.dart
@@ -30,11 +30,11 @@ class _ToDoAppComponent extends FluxComponent<ToDoActions, ToDoStore> {
     store.todos.forEach((Todo todo) {
       todoListItems.add(TodoListItem({'todo': todo, 'onClick': _completeTodo}));
     });
-    ReactElement? todoList = react.div({'className': 'list-group'}, todoListItems);
+    var todoList = react.div({'className': 'list-group'}, todoListItems);
 
-    ReactElement? pageHeader =
+    var pageHeader =
         react.div({'className': 'page-header'}, react.h1({}, 'My Todos'));
-    ReactElement? clearButton = react.button(
+    var clearButton = react.button(
         {'onClick': _clearList, 'disabled': store.todos.length == 0},
         'Clear Todo List');
 

--- a/example/web/todo_app/components/todo_app_component.dart
+++ b/example/web/todo_app/components/todo_app_component.dart
@@ -48,7 +48,7 @@ class _ToDoAppComponent extends FluxComponent<ToDoActions, ToDoStore> {
   }
 
   _clearList(_) {
-    this.actions.clearTodoList();
+    this.actions.clearTodoList(null);
   }
 
   _createTodo(String value) {

--- a/example/web/todo_app/components/todo_app_component.dart
+++ b/example/web/todo_app/components/todo_app_component.dart
@@ -55,7 +55,7 @@ class _ToDoAppComponent extends FluxComponent<ToDoActions, ToDoStore> {
     this.actions.createTodo(Todo(value));
   }
 
-  _completeTodo(todo) {
+  _completeTodo(Todo todo) {
     this.actions.completeTodo(todo);
   }
 }

--- a/example/web/todo_app/components/todo_app_component.dart
+++ b/example/web/todo_app/components/todo_app_component.dart
@@ -30,11 +30,11 @@ class _ToDoAppComponent extends FluxComponent<ToDoActions, ToDoStore> {
     store.todos.forEach((Todo todo) {
       todoListItems.add(TodoListItem({'todo': todo, 'onClick': _completeTodo}));
     });
-    var todoList = react.div({'className': 'list-group'}, todoListItems);
+    ReactElement? todoList = react.div({'className': 'list-group'}, todoListItems);
 
-    var pageHeader =
+    ReactElement? pageHeader =
         react.div({'className': 'page-header'}, react.h1({}, 'My Todos'));
-    var clearButton = react.button(
+    ReactElement? clearButton = react.button(
         {'onClick': _clearList, 'disabled': store.todos.length == 0},
         'Clear Todo List');
 

--- a/example/web/todo_app/components/todo_list_item.dart
+++ b/example/web/todo_app/components/todo_list_item.dart
@@ -21,8 +21,8 @@ import '../store.dart';
 var TodoListItem = react.registerComponent(() => _TodoListItem());
 
 class _TodoListItem extends react.Component2 {
-  Todo get todo => props['todo'] as Todo;
-  Function get onClick => props['onClick'] as Function;
+  Todo get todo => props['todo'] as Todo/*!*/;
+  Function get onClick => props['onClick'] as Function/*!*/;
 
   get defaultProps => {'todo': null};
 

--- a/example/web/todo_app/components/todo_list_item.dart
+++ b/example/web/todo_app/components/todo_list_item.dart
@@ -21,8 +21,8 @@ import '../store.dart';
 var TodoListItem = react.registerComponent(() => _TodoListItem());
 
 class _TodoListItem extends react.Component2 {
-  Todo get todo => props['todo'] as Todo/*!*/;
-  Function get onClick => props['onClick'] as Function/*!*/;
+  Todo get todo => props['todo'] as Todo;
+  Function get onClick => props['onClick'] as Function;
 
   get defaultProps => {'todo': null};
 

--- a/example/web/todo_app/components/todo_list_item.dart
+++ b/example/web/todo_app/components/todo_list_item.dart
@@ -21,8 +21,8 @@ import '../store.dart';
 var TodoListItem = react.registerComponent(() => _TodoListItem());
 
 class _TodoListItem extends react.Component2 {
-  Todo get todo => props['todo'];
-  Function get onClick => props['onClick'];
+  Todo get todo => props['todo'] as Todo;
+  Function get onClick => props['onClick'] as Function;
 
   get defaultProps => {'todo': null};
 

--- a/example/web/todo_app/store.dart
+++ b/example/web/todo_app/store.dart
@@ -29,9 +29,10 @@ class ToDoStore extends Store {
   ToDoStore(ToDoActions this._actions) {
     _todos = [];
 
-    triggerOnActionV2(_actions.createTodo, (todo) => _todos.add(todo));
-    triggerOnActionV2(_actions.completeTodo, (todo) => todo.completed = true);
-    triggerOnActionV2(_actions.deleteTodo, (todo) => _todos.remove(todo));
+    triggerOnActionV2(_actions.createTodo, (Todo todo) => _todos.add(todo));
+    triggerOnActionV2(
+        _actions.completeTodo, (Todo todo) => todo.completed = true);
+    triggerOnActionV2(_actions.deleteTodo, (Todo todo) => _todos.remove(todo));
     triggerOnActionV2(_actions.clearTodoList, (_) => _todos = []);
   }
 }

--- a/example/web/todo_app/store.dart
+++ b/example/web/todo_app/store.dart
@@ -20,15 +20,13 @@ import 'actions.dart';
 
 class ToDoStore extends Store {
   /// Public data
-  List<Todo> _todos;
+  List<Todo> _todos = [];
   List<Todo> get todos => _todos;
 
   /// Internals
   ToDoActions _actions;
 
   ToDoStore(ToDoActions this._actions) {
-    _todos = [];
-
     triggerOnActionV2(_actions.createTodo, (Todo todo) => _todos.add(todo));
     triggerOnActionV2(
         _actions.completeTodo, (Todo todo) => todo.completed = true);

--- a/example/web/todo_app/store.dart
+++ b/example/web/todo_app/store.dart
@@ -31,7 +31,7 @@ class ToDoStore extends Store {
     triggerOnActionV2(
         _actions.completeTodo, (Todo todo) => todo.completed = true);
     triggerOnActionV2(_actions.deleteTodo, (Todo todo) => _todos.remove(todo));
-    triggerOnActionV2(_actions.clearTodoList, (dynamic _) => _todos = []);
+    triggerOnActionV2(_actions.clearTodoList, (_) => _todos = []);
   }
 }
 

--- a/example/web/todo_app/store.dart
+++ b/example/web/todo_app/store.dart
@@ -31,7 +31,7 @@ class ToDoStore extends Store {
     triggerOnActionV2(
         _actions.completeTodo, (Todo todo) => todo.completed = true);
     triggerOnActionV2(_actions.deleteTodo, (Todo todo) => _todos.remove(todo));
-    triggerOnActionV2(_actions.clearTodoList, (_) => _todos = []);
+    triggerOnActionV2(_actions.clearTodoList, (dynamic _) => _todos = []);
   }
 }
 

--- a/example/web/todo_app/todo_app.dart
+++ b/example/web/todo_app/todo_app.dart
@@ -30,7 +30,6 @@ main() async {
 
   // render the component
   react_client.setClientConfiguration();
-  react_dom.render(
-      ToDoAppComponent({'actions': actions, 'store': store}),
+  react_dom.render(ToDoAppComponent({'actions': actions, 'store': store}),
       querySelector('#content-container'));
 }

--- a/example/web/todo_app/todo_app.dart
+++ b/example/web/todo_app/todo_app.dart
@@ -16,7 +16,6 @@ library w_flux.example.todo_app;
 
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' as react_client;
 
@@ -32,6 +31,6 @@ main() async {
   // render the component
   react_client.setClientConfiguration();
   react_dom.render(
-      ErrorBoundary()(ToDoAppComponent({'actions': actions, 'store': store})),
+      ToDoAppComponent({'actions': actions, 'store': store}),
       querySelector('#content-container'));
 }

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -49,7 +49,7 @@ class Action<T> extends Object with Disposable implements Function {
   @override
   String get disposableTypeName => 'Action';
 
-  List _listeners = [];
+  List<_ActionListener<T>> _listeners = [];
 
   /// Dispatch this [Action] to all listeners. If a payload is supplied, it will
   /// be passed to each listener's callback, otherwise null will be passed.
@@ -65,7 +65,8 @@ class Action<T> extends Object with Disposable implements Function {
     // a [Stream]-based action implementation. At smaller sample sizes this
     // implementation slows down in comparison, yielding average times of 0.1 ms
     // for stream-based actions vs. 0.14 ms for this action implementation.
-    Future callListenerInMicrotask(l) => Future.microtask(() => l(payload));
+    Future callListenerInMicrotask(_ActionListener<T> l) =>
+        Future.microtask(() => l(payload));
     return Future.wait(_listeners.map(callListenerInMicrotask));
   }
 
@@ -81,7 +82,7 @@ class Action<T> extends Object with Disposable implements Function {
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
-  ActionSubscription listen(dynamic onData(T event)) {
+  ActionSubscription listen(dynamic Function(T event) onData) {
     _listeners.add(onData);
     return ActionSubscription(() => _listeners.remove(onData));
   }
@@ -96,6 +97,8 @@ class Action<T> extends Object with Disposable implements Function {
     return identical(this, other);
   }
 }
+
+typedef _ActionListener<T> = dynamic Function(T event);
 
 /// A subscription used to cancel registered listeners to an [Action].
 class ActionSubscription {

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -49,11 +49,11 @@ class Action<T> extends Object with Disposable implements Function {
   @override
   String get disposableTypeName => 'Action';
 
-  List<_ActionListener<T>> _listeners = [];
+  List<_ActionListener<T?>> _listeners = [];
 
   /// Dispatch this [Action] to all listeners. If a payload is supplied, it will
   /// be passed to each listener's callback, otherwise null will be passed.
-  Future call([T payload]) {
+  Future call([T? payload]) {
     // Invoke all listeners in a microtask to enable waiting on futures. The
     // microtask queue is emptied before the event loop continues. This ensures
     // synchronous listeners are invoked in the current tick of the event loop
@@ -65,7 +65,7 @@ class Action<T> extends Object with Disposable implements Function {
     // a [Stream]-based action implementation. At smaller sample sizes this
     // implementation slows down in comparison, yielding average times of 0.1 ms
     // for stream-based actions vs. 0.14 ms for this action implementation.
-    Future callListenerInMicrotask(_ActionListener<T> l) =>
+    Future callListenerInMicrotask(_ActionListener<T?> l) =>
         Future.microtask(() => l(payload));
     return Future.wait(_listeners.map(callListenerInMicrotask));
   }
@@ -82,7 +82,7 @@ class Action<T> extends Object with Disposable implements Function {
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
-  ActionSubscription listen(dynamic Function(T event) onData) {
+  ActionSubscription listen(dynamic Function(T? event) onData) {
     _listeners.add(onData);
     return ActionSubscription(() => _listeners.remove(onData));
   }
@@ -102,14 +102,14 @@ typedef _ActionListener<T> = dynamic Function(T event);
 
 /// A subscription used to cancel registered listeners to an [Action].
 class ActionSubscription {
-  Function _onCancel;
+  Function? _onCancel;
 
   ActionSubscription(this._onCancel);
 
   /// Cancel this subscription to an [Action]
   void cancel() {
     if (_onCancel != null) {
-      _onCancel();
+      _onCancel!();
       _onCancel = null;
     }
   }

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -20,11 +20,22 @@ import 'package:w_common/disposable.dart';
 
 import 'package:w_flux/src/constants.dart' show v3Deprecation;
 
+/// Like [Action2], but payloads cannot be made non-nullable since the argument
+/// to [call] is optional.
+@Deprecated('Use Action2 instead, which supports non-nullable payloads.')
+class Action<T> extends Action2<T?> {
+  @override
+  String get disposableTypeName => 'Action';
+
+  @override
+  Future call([T? payload]) => super.call(payload);
+}
+
 /// A command that can be dispatched and listened to.
 ///
-/// An [Action] manages a collection of listeners and the manner of
+/// An [Action2] manages a collection of listeners and the manner of
 /// their invocation. It *does not* rely on [Stream] for managing listeners. By
-/// managing its own listeners, an [Action] can track a [Future] that completes
+/// managing its own listeners, an [Action2] can track a [Future] that completes
 /// when all registered listeners have completed. This allows consumers to use
 /// `await` to wait for an action to finish processing.
 ///
@@ -45,15 +56,15 @@ import 'package:w_flux/src/constants.dart' show v3Deprecation;
 /// when a consumer needs to check state changes immediately after invoking an
 /// action.
 ///
-class Action<T> extends Object with Disposable implements Function {
+class Action2<T> extends Object with Disposable implements Function {
   @override
-  String get disposableTypeName => 'Action';
+  String get disposableTypeName => 'Action2';
 
-  List<_ActionListener<T?>> _listeners = [];
+  List<_ActionListener<T>> _listeners = [];
 
   /// Dispatch this [Action] to all listeners. If a payload is supplied, it will
   /// be passed to each listener's callback, otherwise null will be passed.
-  Future call([T? payload]) {
+  Future call(T payload) {
     // Invoke all listeners in a microtask to enable waiting on futures. The
     // microtask queue is emptied before the event loop continues. This ensures
     // synchronous listeners are invoked in the current tick of the event loop
@@ -65,7 +76,7 @@ class Action<T> extends Object with Disposable implements Function {
     // a [Stream]-based action implementation. At smaller sample sizes this
     // implementation slows down in comparison, yielding average times of 0.1 ms
     // for stream-based actions vs. 0.14 ms for this action implementation.
-    Future callListenerInMicrotask(_ActionListener<T?> l) =>
+    Future callListenerInMicrotask(_ActionListener<T> l) =>
         Future.microtask(() => l(payload));
     return Future.wait(_listeners.map(callListenerInMicrotask));
   }
@@ -82,7 +93,7 @@ class Action<T> extends Object with Disposable implements Function {
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
-  ActionSubscription listen(dynamic Function(T? event) onData) {
+  ActionSubscription listen(dynamic Function(T event) onData) {
     _listeners.add(onData);
     return ActionSubscription(() => _listeners.remove(onData));
   }

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -62,8 +62,8 @@ class Action2<T> extends Object with Disposable implements Function {
 
   List<_ActionListener<T>> _listeners = [];
 
-  /// Dispatch this [Action] to all listeners. If a payload is supplied, it will
-  /// be passed to each listener's callback, otherwise null will be passed.
+  /// Dispatch this [Action2] to all listeners. The non-nullable payload will
+  /// be passed to each listener's callback.
   Future call(T payload) {
     // Invoke all listeners in a microtask to enable waiting on futures. The
     // microtask queue is emptied before the event loop continues. This ensures
@@ -81,7 +81,7 @@ class Action2<T> extends Object with Disposable implements Function {
     return Future.wait(_listeners.map(callListenerInMicrotask));
   }
 
-  /// Cancel all subscriptions that exist on this [Action] as a result of
+  /// Cancel all subscriptions that exist on this [Action2] as a result of
   /// [listen] being called. Useful when tearing down a flux cycle in some
   /// module or unit test.
   @Deprecated('Use (and await) dispose() instead. $v3Deprecation')
@@ -89,7 +89,7 @@ class Action2<T> extends Object with Disposable implements Function {
     _listeners.clear();
   }
 
-  /// Supply a callback that will be called any time this [Action] is
+  /// Supply a callback that will be called any time this [Action2] is
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
@@ -111,13 +111,13 @@ class Action2<T> extends Object with Disposable implements Function {
 
 typedef _ActionListener<T> = dynamic Function(T event);
 
-/// A subscription used to cancel registered listeners to an [Action].
+/// A subscription used to cancel registered listeners to an [Action2].
 class ActionSubscription {
   Function? _onCancel;
 
   ActionSubscription(this._onCancel);
 
-  /// Cancel this subscription to an [Action]
+  /// Cancel this subscription to an [Action2]
   void cancel() {
     if (_onCancel != null) {
       _onCancel!();

--- a/lib/src/component_common.dart
+++ b/lib/src/component_common.dart
@@ -34,7 +34,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   /// There is no strict rule on the [ActionsT] type. Depending on application
   /// structure, there may be [Action]s available directly on this object, or
   /// this object may represent a hierarchy of actions.
-  ActionsT get actions => this.props['actions'] as ActionsT;
+  ActionsT/*!*/ get actions => this.props['actions'] as ActionsT;
 
   /// The class instance defined by [StoresT]. This object should either be an
   /// instance of [Store] or should provide access to one or more [Store]s.
@@ -52,7 +52,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   /// [StoresT] should be a class that provides access to these multiple stores.
   /// Then, you can explicitly select the [Store] instances that should be
   /// listened to by overriding [redrawOn].
-  StoresT get store => this.props['store'] as StoresT;
+  StoresT/*!*/ get store => this.props['store'] as StoresT;
 
   @mustCallSuper
   @override
@@ -77,7 +77,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   ///
   /// Override to set up custom listener behavior.
   @protected
-  void listenToStoreForRedraw(Store store) {
+  void listenToStoreForRedraw(Store/*!*/ store) {
     listenToStream(store, handleRedrawOn);
   }
 
@@ -114,7 +114,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   ///
   ///     @override
   ///     redrawOn() => [store.tasks, store.users];
-  List<Store> redrawOn() {
+  List<Store/*!*/> redrawOn() {
     if (store is Store) {
       return [store as Store];
     } else {
@@ -130,7 +130,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   /// If possible, however, [redrawOn] should be used instead of this in order
   /// to avoid keeping additional state within this component and manually
   /// managing redraws.
-  Map<Store, StoreHandler> getStoreHandlers() {
+  Map<Store/*!*/, StoreHandler> getStoreHandlers() {
     return {};
   }
 

--- a/lib/src/component_common.dart
+++ b/lib/src/component_common.dart
@@ -34,7 +34,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   /// There is no strict rule on the [ActionsT] type. Depending on application
   /// structure, there may be [Action]s available directly on this object, or
   /// this object may represent a hierarchy of actions.
-  ActionsT/*!*/ get actions => this.props['actions'] as ActionsT;
+  ActionsT get actions => this.props['actions'] as ActionsT;
 
   /// The class instance defined by [StoresT]. This object should either be an
   /// instance of [Store] or should provide access to one or more [Store]s.
@@ -52,7 +52,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   /// [StoresT] should be a class that provides access to these multiple stores.
   /// Then, you can explicitly select the [Store] instances that should be
   /// listened to by overriding [redrawOn].
-  StoresT/*!*/ get store => this.props['store'] as StoresT;
+  StoresT get store => this.props['store'] as StoresT;
 
   @mustCallSuper
   @override
@@ -77,7 +77,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   ///
   /// Override to set up custom listener behavior.
   @protected
-  void listenToStoreForRedraw(Store/*!*/ store) {
+  void listenToStoreForRedraw(Store store) {
     listenToStream(store, handleRedrawOn);
   }
 
@@ -114,7 +114,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   ///
   ///     @override
   ///     redrawOn() => [store.tasks, store.users];
-  List<Store/*!*/> redrawOn() {
+  List<Store> redrawOn() {
     if (store is Store) {
       return [store as Store];
     } else {
@@ -130,7 +130,7 @@ abstract class FluxComponentCommon<ActionsT, StoresT> extends react.Component
   /// If possible, however, [redrawOn] should be used instead of this in order
   /// to avoid keeping additional state within this component and manually
   /// managing redraws.
-  Map<Store/*!*/, StoreHandler> getStoreHandlers() {
+  Map<Store, StoreHandler> getStoreHandlers() {
     return {};
   }
 

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -9,14 +9,14 @@ class _RedrawScheduler implements Function {
   Map<BatchedRedraws, List<Function>> _components =
       <BatchedRedraws, List<Function>>{};
 
-  void call(BatchedRedraws component, [callback()]) {
+  void call(BatchedRedraws component, [callback()?]) {
     if (_components.isEmpty) {
       _tick();
     }
 
     _components[component] ??= [];
 
-    if (callback != null) _components[component].add(callback);
+    if (callback != null) _components[component]!.add(callback);
   }
 
   Future _tick() async {
@@ -33,7 +33,7 @@ class _RedrawScheduler implements Function {
         continue;
       }
 
-      Function() chainedCallbacks;
+      Function()? chainedCallbacks;
 
       if (callbacks.isNotEmpty) {
         chainedCallbacks = () {
@@ -67,5 +67,5 @@ _RedrawScheduler _scheduleRedraw = _RedrawScheduler();
 class BatchedRedraws {
   bool shouldBatchRedraw = true;
 
-  void redraw([callback()]) => _scheduleRedraw(this, callback);
+  void redraw([callback()?]) => _scheduleRedraw(this, callback);
 }

--- a/lib/src/mixins/batched_redraws.dart
+++ b/lib/src/mixins/batched_redraws.dart
@@ -43,7 +43,7 @@ class _RedrawScheduler implements Function {
         };
       }
 
-      (component as react.Component)?.setState({}, chainedCallbacks);
+      (component as react.Component).setState({}, chainedCallbacks);
 
       // Waits a tick to prevent holding up the thread, allowing other scripts to execute in between each component.
       await Future(() {});

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -141,7 +141,7 @@ class Store extends Stream<Store> with Disposable {
   /// Deprecated: 2.9.5
   /// To be removed: 3.0.0
   @deprecated
-  triggerOnAction(Action action, [void onAction(payload)?]) {
+  triggerOnAction(Action2 action, [void onAction(payload)?]) {
     triggerOnActionV2(action, onAction);
   }
 
@@ -153,8 +153,8 @@ class Store extends Stream<Store> with Disposable {
   /// called until that future has resolved.
   ///
   /// If the `Store` has been disposed, this method throws a [StateError].
-  void triggerOnActionV2<T>(Action<T> action,
-      [FutureOr<dynamic> onAction(T? payload)?]) {
+  void triggerOnActionV2<T>(Action2<T> action,
+      [FutureOr<dynamic> onAction(T payload)?]) {
     if (isOrWillBeDisposed) {
       throw StateError('Store of type $runtimeType has been disposed');
     }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -47,7 +47,7 @@ class Store extends Stream<Store> with Disposable {
   final StreamController<Store> _streamController;
 
   /// Broadcast stream of "data updated" events. Listened to in [listen].
-  Stream<Store> _stream;
+  Stream<Store>/*!*/ _stream;
 
   /// Construct a new [Store] instance.
   Store() : _streamController = StreamController<Store>.broadcast() {

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -47,7 +47,7 @@ class Store extends Stream<Store> with Disposable {
   final StreamController<Store> _streamController;
 
   /// Broadcast stream of "data updated" events. Listened to in [listen].
-  Stream<Store>/*!*/ _stream;
+  Stream<Store> _stream;
 
   /// Construct a new [Store] instance.
   Store() : _streamController = StreamController<Store>.broadcast() {
@@ -94,8 +94,8 @@ class Store extends Stream<Store> with Disposable {
   /// It is the caller's responsibility to cancel the subscription when
   /// needed.
   @override
-  StreamSubscription<Store> listen(StoreHandler onData,
-      {Function onError, void onDone(), bool cancelOnError}) {
+  StreamSubscription<Store> listen(StoreHandler? onData,
+      {Function? onError, void onDone()?, bool? cancelOnError}) {
     if (isDisposed) {
       throw StateError('Store of type $runtimeType has been disposed');
     }
@@ -141,7 +141,7 @@ class Store extends Stream<Store> with Disposable {
   /// Deprecated: 2.9.5
   /// To be removed: 3.0.0
   @deprecated
-  triggerOnAction(Action action, [void onAction(payload)]) {
+  triggerOnAction(Action action, [void onAction(payload)?]) {
     triggerOnActionV2(action, onAction);
   }
 
@@ -154,7 +154,7 @@ class Store extends Stream<Store> with Disposable {
   ///
   /// If the `Store` has been disposed, this method throws a [StateError].
   void triggerOnActionV2<T>(Action<T> action,
-      [FutureOr<dynamic> onAction(T payload)]) {
+      [FutureOr<dynamic> onAction(T? payload)?]) {
     if (isOrWillBeDisposed) {
       throw StateError('Store of type $runtimeType has been disposed');
     }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -47,7 +47,7 @@ class Store extends Stream<Store> with Disposable {
   final StreamController<Store> _streamController;
 
   /// Broadcast stream of "data updated" events. Listened to in [listen].
-  Stream<Store> _stream;
+  late Stream<Store> _stream;
 
   /// Construct a new [Store] instance.
   Store() : _streamController = StreamController<Store>.broadcast() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,4 +25,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/Workiva/react-dart.git
-      ref: null-safety-manual-2
+      ref: v7_wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Flux library for uni-directional dataflow inspired by reflux and Fa
 homepage: https://github.com/Workiva/w_flux
 
 environment:
-  sdk: ">=2.11.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   meta: ^1.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,11 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   dart_dev: ^4.0.0
   dependency_validator: ^3.0.0
-  test: ^1.18.2 
+  test: ^1.18.2
+
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: null-safety-manual-2

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -222,7 +222,7 @@ void main() {
       }, skip: true);
     });
   });
-  
+
   group('Action2', () {
     late Action2<String> action;
 

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -222,4 +222,193 @@ void main() {
       }, skip: true);
     });
   });
+  
+  group('Action2', () {
+    late Action2<String> action;
+
+    setUp(() {
+      action = Action2<String>();
+    });
+
+    test('should only be equivalent to itself', () {
+      Action2 _action = Action2();
+      Action2 _action2 = Action2();
+      expect(_action == _action, isTrue);
+      expect(_action == _action2, isFalse);
+    });
+
+    test('should support dispatch with a payload', () async {
+      Completer c = Completer();
+      action.listen((payload) {
+        expect(payload, equals('990 guerrero'));
+        c.complete();
+      });
+
+      action('990 guerrero');
+      return c.future;
+    });
+
+    test('should dispatch by default when called', () async {
+      Completer c = Completer();
+      action.listen((payload) {
+        expect(payload, equals('990 guerrero'));
+        c.complete();
+      });
+
+      action('990 guerrero');
+      return c.future;
+    });
+
+    group('dispatch', () {
+      test(
+          'should invoke and complete synchronous listeners in future event in '
+          'event queue', () async {
+        var action = Action2();
+        var listenerCompleted = false;
+        action.listen((_) {
+          listenerCompleted = true;
+        });
+
+        // No immediate invocation.
+        action(null);
+        expect(listenerCompleted, isFalse);
+
+        // Invoked during the next scheduled event in the queue.
+        await Future(() => {});
+        expect(listenerCompleted, isTrue);
+      });
+
+      test(
+          'should invoke asynchronous listeners in future event and complete '
+          'in another future event', () async {
+        var action = Action2();
+        var listenerInvoked = false;
+        var listenerCompleted = false;
+        action.listen((_) async {
+          listenerInvoked = true;
+          await Future(() => listenerCompleted = true);
+        });
+
+        // No immediate invocation.
+        action(null);
+        expect(listenerInvoked, isFalse);
+
+        // Invoked during next scheduled event in the queue.
+        await Future(() => {});
+        expect(listenerInvoked, isTrue);
+        expect(listenerCompleted, isFalse);
+
+        // Completed in next next scheduled event.
+        await Future(() => {});
+        expect(listenerCompleted, isTrue);
+      });
+
+      test('should complete future after listeners complete', () async {
+        var action = Action2();
+        var asyncListenerCompleted = false;
+        action.listen((_) async {
+          await Future.delayed(Duration(milliseconds: 100), () {
+            asyncListenerCompleted = true;
+          });
+        });
+
+        Future<dynamic>? future = action(null);
+        expect(asyncListenerCompleted, isFalse);
+
+        await future;
+        expect(asyncListenerCompleted, isTrue);
+      });
+
+      test('should surface errors in listeners', () {
+        var action = Action2();
+        action.listen((_) => throw UnimplementedError());
+        expect(action(0), throwsUnimplementedError);
+      });
+    });
+
+    group('listen', () {
+      test('should stop listening when subscription is canceled', () async {
+        var action = Action2();
+        var listened = false;
+        var subscription = action.listen((_) => listened = true);
+
+        await action(null);
+        expect(listened, isTrue);
+
+        listened = false;
+        subscription.cancel();
+        await action(null);
+        expect(listened, isFalse);
+      });
+
+      test('should stop listening when listeners are cleared', () async {
+        var action = Action2();
+        var listened = false;
+        action.listen((_) => listened = true);
+
+        await action(null);
+        expect(listened, isTrue);
+
+        listened = false;
+        await action.dispose();
+        await action(null);
+        expect(listened, isFalse);
+      });
+
+      test('should stop listening when actions are disposed', () async {
+        var action = Action2();
+        var listened = false;
+        action.listen((_) => listened = true);
+
+        await action(null);
+        expect(listened, isTrue);
+
+        listened = false;
+        await action.dispose();
+        await action(null);
+        expect(listened, isFalse);
+      });
+    });
+
+    group('benchmarks', () {
+      test('should dispatch actions faster than streams :(', () async {
+        const int sampleSize = 1000;
+        var stopwatch = Stopwatch();
+
+        var awaitableAction = Action2();
+        awaitableAction.listen((_) => {});
+        awaitableAction.listen((_) async {});
+        stopwatch.start();
+        for (var i = 0; i < sampleSize; i++) {
+          await awaitableAction(null);
+        }
+        stopwatch.stop();
+        var averageActionDispatchTime =
+            stopwatch.elapsedMicroseconds / sampleSize / 1000.0;
+
+        stopwatch.reset();
+
+        late Completer syncCompleter;
+        late Completer asyncCompleter;
+        var action = Action2();
+        action.listen((_) => syncCompleter.complete());
+        action.listen((_) async {
+          asyncCompleter.complete();
+        });
+        stopwatch.start();
+        for (var i = 0; i < sampleSize; i++) {
+          syncCompleter = Completer();
+          asyncCompleter = Completer();
+          action(null);
+          await Future.wait([syncCompleter.future, asyncCompleter.future]);
+        }
+        stopwatch.stop();
+        var averageStreamDispatchTime =
+            stopwatch.elapsedMicroseconds / sampleSize / 1000.0;
+
+        print('awaitable action (ms): $averageActionDispatchTime; '
+            'stream-based action (ms): $averageStreamDispatchTime');
+      }, skip: true);
+    });
+  });
 }

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -22,7 +22,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Action', () {
-    Action<String> action;
+    late Action<String> action;
 
     setUp(() {
       action = Action<String>();
@@ -39,7 +39,7 @@ void main() {
       Completer c = Completer();
       Action<String> _action = Action<String>();
 
-      _action.listen((String payload) {
+      _action.listen((String? payload) {
         expect(payload, equals(null));
         c.complete();
       });
@@ -50,7 +50,7 @@ void main() {
 
     test('should support dispatch with a payload', () async {
       Completer c = Completer();
-      action.listen((String payload) {
+      action.listen((String? payload) {
         expect(payload, equals('990 guerrero'));
         c.complete();
       });
@@ -61,7 +61,7 @@ void main() {
 
     test('should dispatch by default when called', () async {
       Completer c = Completer();
-      action.listen((String payload) {
+      action.listen((String? payload) {
         expect(payload, equals('990 guerrero'));
         c.complete();
       });
@@ -123,7 +123,7 @@ void main() {
           });
         });
 
-        var future = action();
+        Future<dynamic>? future = action();
         expect(asyncListenerCompleted, isFalse);
 
         await future;
@@ -199,8 +199,8 @@ void main() {
 
         stopwatch.reset();
 
-        Completer syncCompleter;
-        Completer asyncCompleter;
+        late Completer syncCompleter;
+        late Completer asyncCompleter;
         var action = Action();
         action.listen((_) => syncCompleter.complete());
         action.listen((_) async {

--- a/test/component_server_test.dart
+++ b/test/component_server_test.dart
@@ -188,7 +188,7 @@ class TestDefaultComponent extends FluxComponent {
 
   render() => react.div({});
 
-  redraw([callback()]) {
+  redraw([callback()?]) {
     numberOfRedraws += 1;
   }
 }
@@ -212,7 +212,7 @@ class TestRedrawOnComponent extends FluxComponent<TestActions, TestStores> {
 
   redrawOn() => [store.store1, store.store2];
 
-  redraw([callback()]) {
+  redraw([callback()?]) {
     numberOfRedraws += 1;
   }
 }
@@ -231,7 +231,7 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
     numberOfHandlerCalls += 1;
   }
 
-  redraw([callback()]) {
+  redraw([callback()?]) {
     numberOfRedraws += 1;
   }
 }

--- a/test/component_test.dart
+++ b/test/component_test.dart
@@ -221,7 +221,7 @@ class TestDefaultComponent extends FluxComponent {
 
   render() => react.div({});
 
-  void setState(_, [callback()]) {
+  void setState(_, [callback()?]) {
     numberOfRedraws++;
     if (callback != null) callback();
   }
@@ -246,7 +246,7 @@ class TestRedrawOnComponent extends FluxComponent<TestActions, TestStores> {
 
   redrawOn() => [store.store1, store.store2];
 
-  void setState(_, [callback()]) {
+  void setState(_, [callback()?]) {
     numberOfRedraws++;
     if (callback != null) callback();
   }
@@ -266,7 +266,7 @@ class TestHandlerPrecedence extends FluxComponent<TestActions, TestStores> {
     numberOfHandlerCalls += 1;
   }
 
-  void setState(_, [callback()]) {
+  void setState(_, [callback()?]) {
     numberOfRedraws++;
     if (callback != null) callback();
   }
@@ -278,7 +278,7 @@ class TestHandlerLifecycle extends FluxComponent<TestActions, TestStore> {
 
   render() => react.div({});
 
-  void setState(_, [callback()]) {
+  void setState(_, [callback()?]) {
     numberOfRedraws++;
     if (callback != null) callback();
   }

--- a/test/mixins/batched_redraws_test.dart
+++ b/test/mixins/batched_redraws_test.dart
@@ -28,7 +28,7 @@ class _TestComponent extends react.Component with BatchedRedraws {
 
   dynamic render() => '';
 
-  void setState(_, [callback()]) {
+  void setState(_, [callback()?]) {
     renderCount++;
     if (callback != null) callback();
   }
@@ -41,8 +41,8 @@ void main() {
   }
 
   group('ScheduledRedraws', () {
-    _TestComponent component;
-    List calls;
+    late _TestComponent component;
+    late List calls;
 
     setUp(() {
       component = _TestComponent();

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -143,7 +143,7 @@ void main() {
         () {
       Action<num> _action = Action<num>();
       num counter = 0;
-      store.triggerOnActionV2(_action, (payload) => counter = payload);
+      store.triggerOnActionV2(_action, (num payload) => counter = payload);
       store.listen(expectAsync1((payload) {
         expect(payload, store);
         expect(counter, 17);

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -47,7 +47,7 @@ class MockTransformer implements StreamTransformer<Store, Store> {
 
 void main() {
   group('Store', () {
-    Store store;
+    late Store store;
 
     setUp(() {
       store = Store();
@@ -142,8 +142,8 @@ void main() {
         'should execute a given method and then trigger in response to an action with payload',
         () {
       Action<num> _action = Action<num>();
-      num counter = 0;
-      store.triggerOnActionV2(_action, (num payload) => counter = payload);
+      num? counter = 0;
+      store.triggerOnActionV2(_action, (num? payload) => counter = payload);
       store.listen(expectAsync1((payload) {
         expect(payload, store);
         expect(counter, 17);


### PR DESCRIPTION
## Motivation
We need to make w_flux null safe.

w_flux's Action class specifically has some issues when migrating to null safety that need special attention and migration.

Due to Action.call having an optional paramater, it must be typed as nullable. However, this means that we can't make listener payloads non-nullable, since there's no guarantee that the argument was specified.

```
class Action<T> /*...*/ {
  Future call([T? payload]) { 
    for (final listener in _listeners) {
      await listener(payload);
      //             ^^^^^^^
      // Error: can't assign T? to T
    }
  }
  
  ActionSubscription listen(dynamic onData(T event)) {/*...*/}
  
  /*...*/
}
```
As a result, we have to make the listener argument nullable:

  ActionSubscription listen(dynamic onData(T? event)) {/*...*/}
To be able to support non-nullable payloads (in addition to nullable payloads), we'll want to make a new Action2 class with required payloads, and migrate consumers over to it before those consumers migrate to null safety.

## Changes
- Migrate w_flux to null safety
- Create Action2 class that supports non-nullable payloads (in addition to nullable payloads)
- Add tests  coverage for new Action2 class

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#manual-testing-criteria
