### PR TITLE
FEA-2771 Add ActionV2 w/o null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## 2.11.0
+Create ActionV2 class with non-nullable payloads in preparation for null-safety.
+
 ## 2.10.15
 
 - Dependency upgrades

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -20,10 +20,10 @@ import 'package:w_common/disposable.dart';
 
 import 'package:w_flux/src/constants.dart' show v3Deprecation;
 
-/// Like [Action2], but payloads cannot be made non-nullable since the argument
+/// Like [ActionV2], but payloads cannot be made non-nullable since the argument
 /// to [call] is optional.
-@Deprecated('Use Action2 instead, which supports non-nullable payloads.')
-class Action<T> extends Action2<T> {
+@Deprecated('Use ActionV2 instead, which supports non-nullable payloads.')
+class Action<T> extends ActionV2<T> {
   @override
   String get disposableTypeName => 'Action';
 
@@ -33,9 +33,9 @@ class Action<T> extends Action2<T> {
 
 /// A command that can be dispatched and listened to.
 ///
-/// An [Action2] manages a collection of listeners and the manner of
+/// An [ActionV2] manages a collection of listeners and the manner of
 /// their invocation. It *does not* rely on [Stream] for managing listeners. By
-/// managing its own listeners, an [Action2] can track a [Future] that completes
+/// managing its own listeners, an [ActionV2] can track a [Future] that completes
 /// when all registered listeners have completed. This allows consumers to use
 /// `await` to wait for an action to finish processing.
 ///
@@ -56,13 +56,13 @@ class Action<T> extends Action2<T> {
 /// when a consumer needs to check state changes immediately after invoking an
 /// action.
 ///
-class Action2<T> extends Object with Disposable implements Function {
+class ActionV2<T> extends Object with Disposable implements Function {
   @override
-  String get disposableTypeName => 'Action2';
+  String get disposableTypeName => 'ActionV2';
 
   List<_ActionListener<T>> _listeners = [];
 
-  /// Dispatch this [Action2] to all listeners. The payload will be passed to
+  /// Dispatch this [ActionV2] to all listeners. The payload will be passed to
   /// each listener's callback.
   Future call(T payload) {
     // Invoke all listeners in a microtask to enable waiting on futures. The
@@ -81,7 +81,7 @@ class Action2<T> extends Object with Disposable implements Function {
     return Future.wait(_listeners.map(callListenerInMicrotask));
   }
 
-  /// Cancel all subscriptions that exist on this [Action2] as a result of
+  /// Cancel all subscriptions that exist on this [ActionV2] as a result of
   /// [listen] being called. Useful when tearing down a flux cycle in some
   /// module or unit test.
   @Deprecated('Use (and await) dispose() instead. $v3Deprecation')
@@ -89,7 +89,7 @@ class Action2<T> extends Object with Disposable implements Function {
     _listeners.clear();
   }
 
-  /// Supply a callback that will be called any time this [Action2] is
+  /// Supply a callback that will be called any time this [ActionV2] is
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
@@ -111,13 +111,13 @@ class Action2<T> extends Object with Disposable implements Function {
 
 typedef _ActionListener<T> = dynamic Function(T event);
 
-/// A subscription used to cancel registered listeners to an [Action2].
+/// A subscription used to cancel registered listeners to an [ActionV2].
 class ActionSubscription {
   Function _onCancel;
 
   ActionSubscription(this._onCancel);
 
-  /// Cancel this subscription to an [Action2]
+  /// Cancel this subscription to an [ActionV2]
   void cancel() {
     if (_onCancel != null) {
       _onCancel();

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -62,8 +62,8 @@ class Action2<T> extends Object with Disposable implements Function {
 
   List<_ActionListener<T>> _listeners = [];
 
-  /// Dispatch this [Action2] to all listeners. The non-nullable payload will
-  /// be passed to each listener's callback.
+  /// Dispatch this [Action2] to all listeners. The payload will be passed to
+  /// each listener's callback.
   Future call(T payload) {
     // Invoke all listeners in a microtask to enable waiting on futures. The
     // microtask queue is emptied before the event loop continues. This ensures

--- a/lib/src/action.dart
+++ b/lib/src/action.dart
@@ -20,11 +20,22 @@ import 'package:w_common/disposable.dart';
 
 import 'package:w_flux/src/constants.dart' show v3Deprecation;
 
+/// Like [Action2], but payloads cannot be made non-nullable since the argument
+/// to [call] is optional.
+@Deprecated('Use Action2 instead, which supports non-nullable payloads.')
+class Action<T> extends Action2<T> {
+  @override
+  String get disposableTypeName => 'Action';
+
+  @override
+  Future call([T payload]) => super.call(payload);
+}
+
 /// A command that can be dispatched and listened to.
 ///
-/// An [Action] manages a collection of listeners and the manner of
+/// An [Action2] manages a collection of listeners and the manner of
 /// their invocation. It *does not* rely on [Stream] for managing listeners. By
-/// managing its own listeners, an [Action] can track a [Future] that completes
+/// managing its own listeners, an [Action2] can track a [Future] that completes
 /// when all registered listeners have completed. This allows consumers to use
 /// `await` to wait for an action to finish processing.
 ///
@@ -45,15 +56,15 @@ import 'package:w_flux/src/constants.dart' show v3Deprecation;
 /// when a consumer needs to check state changes immediately after invoking an
 /// action.
 ///
-class Action<T> extends Object with Disposable implements Function {
+class Action2<T> extends Object with Disposable implements Function {
   @override
-  String get disposableTypeName => 'Action';
+  String get disposableTypeName => 'Action2';
 
-  List _listeners = [];
+  List<_ActionListener<T>> _listeners = [];
 
-  /// Dispatch this [Action] to all listeners. If a payload is supplied, it will
-  /// be passed to each listener's callback, otherwise null will be passed.
-  Future call([T payload]) {
+  /// Dispatch this [Action2] to all listeners. The non-nullable payload will
+  /// be passed to each listener's callback.
+  Future call(T payload) {
     // Invoke all listeners in a microtask to enable waiting on futures. The
     // microtask queue is emptied before the event loop continues. This ensures
     // synchronous listeners are invoked in the current tick of the event loop
@@ -65,11 +76,12 @@ class Action<T> extends Object with Disposable implements Function {
     // a [Stream]-based action implementation. At smaller sample sizes this
     // implementation slows down in comparison, yielding average times of 0.1 ms
     // for stream-based actions vs. 0.14 ms for this action implementation.
-    Future callListenerInMicrotask(l) => Future.microtask(() => l(payload));
+    Future callListenerInMicrotask(_ActionListener<T> l) =>
+        Future.microtask(() => l(payload));
     return Future.wait(_listeners.map(callListenerInMicrotask));
   }
 
-  /// Cancel all subscriptions that exist on this [Action] as a result of
+  /// Cancel all subscriptions that exist on this [Action2] as a result of
   /// [listen] being called. Useful when tearing down a flux cycle in some
   /// module or unit test.
   @Deprecated('Use (and await) dispose() instead. $v3Deprecation')
@@ -77,11 +89,11 @@ class Action<T> extends Object with Disposable implements Function {
     _listeners.clear();
   }
 
-  /// Supply a callback that will be called any time this [Action] is
+  /// Supply a callback that will be called any time this [Action2] is
   /// dispatched. A payload of type [T] will be passed to the callback if
   /// supplied at dispatch time, otherwise null will be passed. Returns an
   /// [ActionSubscription] which provides means to cancel the subscription.
-  ActionSubscription listen(dynamic onData(T event)) {
+  ActionSubscription listen(dynamic Function(T event) onData) {
     _listeners.add(onData);
     return ActionSubscription(() => _listeners.remove(onData));
   }
@@ -97,13 +109,15 @@ class Action<T> extends Object with Disposable implements Function {
   }
 }
 
-/// A subscription used to cancel registered listeners to an [Action].
+typedef _ActionListener<T> = dynamic Function(T event);
+
+/// A subscription used to cancel registered listeners to an [Action2].
 class ActionSubscription {
   Function _onCancel;
 
   ActionSubscription(this._onCancel);
 
-  /// Cancel this subscription to an [Action]
+  /// Cancel this subscription to an [Action2]
   void cancel() {
     if (_onCancel != null) {
       _onCancel();

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -29,7 +29,7 @@ typedef StoreHandler = Function(Store event);
 ///
 /// General guidelines with respect to a `Store`'s data:
 /// - A `Store`'s data should not be exposed for direct mutation.
-/// - A `Store`'s data should be mutated internally in response to [Action]s.
+/// - A `Store`'s data should be mutated internally in response to [ActionV2]s.
 /// - A `Store` should expose relevant data ONLY via public getters.
 ///
 /// To receive notifications of a `Store`'s data mutations, `Store`s can be
@@ -141,7 +141,7 @@ class Store extends Stream<Store> with Disposable {
   /// Deprecated: 2.9.5
   /// To be removed: 3.0.0
   @deprecated
-  triggerOnAction(Action action, [void onAction(payload)]) {
+  triggerOnAction(ActionV2 action, [void onAction(payload)]) {
     triggerOnActionV2(action, onAction);
   }
 
@@ -153,7 +153,7 @@ class Store extends Stream<Store> with Disposable {
   /// called until that future has resolved.
   ///
   /// If the `Store` has been disposed, this method throws a [StateError].
-  void triggerOnActionV2<T>(Action<T> action,
+  void triggerOnActionV2<T>(ActionV2<T> action,
       [FutureOr<dynamic> onAction(T payload)]) {
     if (isOrWillBeDisposed) {
       throw StateError('Store of type $runtimeType has been disposed');

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -33,9 +33,9 @@ void main() {
 
     test('should only be equivalent to itself', () {
       Action _action = Action();
-      Action _action2 = Action();
+      Action _ActionV2 = Action();
       expect(_action == _action, isTrue);
-      expect(_action == _action2, isFalse);
+      expect(_action == _ActionV2, isFalse);
     });
 
     test('should support dispatch without a payload', () async {
@@ -208,21 +208,21 @@ void main() {
     });
   });
 
-  group('Action2', () {
-    Action2<String> action;
+  group('ActionV2', () {
+    ActionV2<String> action;
 
     setUp(() {
-      action = Action2<String>();
+      action = ActionV2<String>();
       addTearDown(() async {
         await action.dispose();
       });
     });
 
     test('should only be equivalent to itself', () {
-      Action2 _action = Action2();
-      Action2 _action2 = Action2();
+      ActionV2 _action = ActionV2();
+      ActionV2 _ActionV2 = ActionV2();
       expect(_action == _action, isTrue);
-      expect(_action == _action2, isFalse);
+      expect(_action == _ActionV2, isFalse);
     });
 
     test('should support dispatch by default when called with a payload',
@@ -343,7 +343,7 @@ void main() {
         const int sampleSize = 1000;
         var stopwatch = Stopwatch();
 
-        var awaitableAction = Action2()
+        var awaitableAction = ActionV2()
           ..listen((_) => {})
           ..listen((_) async {});
         stopwatch.start();
@@ -358,7 +358,7 @@ void main() {
 
         Completer syncCompleter;
         Completer asyncCompleter;
-        var action = Action2()
+        var action = ActionV2()
           ..listen((_) => syncCompleter.complete())
           ..listen((_) async {
             asyncCompleter.complete();
@@ -381,10 +381,10 @@ void main() {
   });
 
   group('Null typed', () {
-    Action2<Null> nullAction;
+    ActionV2<Null> nullAction;
 
     setUp(() {
-      nullAction = Action2<Null>();
+      nullAction = ActionV2<Null>();
       addTearDown(() async {
         await nullAction.dispose();
       });
@@ -400,10 +400,10 @@ void main() {
   });
 
   group('void typed', () {
-    Action2<void> voidAction;
+    ActionV2<void> voidAction;
 
     setUp(() {
-      voidAction = Action2<void>();
+      voidAction = ActionV2<void>();
       addTearDown(() async {
         await voidAction.dispose();
       });

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -22,7 +22,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Action', () {
-    late Action<String> action;
+    Action<String> action;
 
     setUp(() {
       action = Action<String>();
@@ -38,7 +38,7 @@ void main() {
     test('should support dispatch without a payload', () async {
       Completer c = Completer();
       Action<String> _action = Action<String>()
-        ..listen((String? payload) {
+        ..listen((String payload) {
           expect(payload, equals(null));
           c.complete();
         });
@@ -49,7 +49,7 @@ void main() {
 
     test('should support dispatch with a payload', () async {
       Completer c = Completer();
-      action.listen((String? payload) {
+      action.listen((String payload) {
         expect(payload, equals('990 guerrero'));
         c.complete();
       });
@@ -60,7 +60,7 @@ void main() {
 
     test('should dispatch by default when called', () async {
       Completer c = Completer();
-      action.listen((String? payload) {
+      action.listen((String payload) {
         expect(payload, equals('990 guerrero'));
         c.complete();
       });
@@ -122,7 +122,7 @@ void main() {
           });
         });
 
-        Future<dynamic>? future = action();
+        Future<dynamic> future = action();
         expect(asyncListenerCompleted, isFalse);
 
         await future;
@@ -197,8 +197,8 @@ void main() {
 
         stopwatch.reset();
 
-        late Completer syncCompleter;
-        late Completer asyncCompleter;
+        Completer syncCompleter;
+        Completer asyncCompleter;
         var action = Action()
           ..listen((_) => syncCompleter.complete())
           ..listen((_) async {
@@ -222,7 +222,7 @@ void main() {
   });
 
   group('Action2', () {
-    late Action2<String> action;
+    Action2<String> action;
 
     setUp(() {
       action = Action2<String>();
@@ -307,7 +307,7 @@ void main() {
           });
         });
 
-        Future<dynamic>? future = action('payload');
+        Future<dynamic> future = action('payload');
         expect(asyncListenerCompleted, isFalse);
 
         await future;
@@ -362,7 +362,7 @@ void main() {
     });
 
     group('Null typed', () {
-      late Action2<Null> nullAction;
+      Action2<Null> nullAction;
 
       setUp(() {
         nullAction = Action2<Null>();
@@ -412,8 +412,8 @@ void main() {
 
         stopwatch.reset();
 
-        late Completer syncCompleter;
-        late Completer asyncCompleter;
+        Completer syncCompleter;
+        Completer asyncCompleter;
         var action = Action2()
           ..listen((_) => syncCompleter.complete())
           ..listen((_) async {

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -26,16 +26,14 @@ void main() {
 
     setUp(() {
       action = Action<String>();
-      addTearDown(() async {
-        await action.dispose();
-      });
+      addTearDown(action.dispose);
     });
 
     test('should only be equivalent to itself', () {
-      Action _action = Action();
-      Action _ActionV2 = Action();
-      expect(_action == _action, isTrue);
-      expect(_action == _ActionV2, isFalse);
+      Action action = Action();
+      Action actionV2 = Action();
+      expect(action == action, isTrue);
+      expect(action == actionV2, isFalse);
     });
 
     test('should support dispatch without a payload', () async {
@@ -213,16 +211,14 @@ void main() {
 
     setUp(() {
       action = ActionV2<String>();
-      addTearDown(() async {
-        await action.dispose();
-      });
+      addTearDown(action.dispose);
     });
 
     test('should only be equivalent to itself', () {
-      ActionV2 _action = ActionV2();
-      ActionV2 _ActionV2 = ActionV2();
-      expect(_action == _action, isTrue);
-      expect(_action == _ActionV2, isFalse);
+      ActionV2 action = ActionV2();
+      ActionV2 actionV2 = ActionV2();
+      expect(action == action, isTrue);
+      expect(action == actionV2, isFalse);
     });
 
     test('should support dispatch by default when called with a payload',
@@ -292,8 +288,8 @@ void main() {
       });
 
       test('should surface errors in listeners', () {
-        var actionWithError = action..listen((_) => throw UnimplementedError());
-        expect(actionWithError('payload'), throwsUnimplementedError);
+        action.listen((_) => throw UnimplementedError());
+        expect(action('payload'), throwsUnimplementedError);
       });
     });
 
@@ -385,9 +381,7 @@ void main() {
 
     setUp(() {
       nullAction = ActionV2<Null>();
-      addTearDown(() async {
-        await nullAction.dispose();
-      });
+      addTearDown(nullAction.dispose);
     });
 
     test('should support dispatch with a null payload', () async {
@@ -404,19 +398,13 @@ void main() {
 
     setUp(() {
       voidAction = ActionV2<void>();
-      addTearDown(() async {
-        await voidAction.dispose();
-      });
+      addTearDown(voidAction.dispose);
     });
 
     test('should support dispatch with a null payload', () async {
-      Completer c = Completer();
-      voidAction.listen((_) {
-        c.complete();
-      });
+      voidAction.listen(expectAsync1((_) {}));
 
       await voidAction(null);
-      return c.future;
     });
   });
 }

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -22,7 +22,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Action', () {
-    Action<String> action;
+    late Action<String> action;
 
     setUp(() {
       action = Action<String>();
@@ -37,36 +37,35 @@ void main() {
 
     test('should support dispatch without a payload', () async {
       Completer c = Completer();
-      Action<String> _action = Action<String>();
+      Action<String> _action = Action<String>()
+        ..listen((String? payload) {
+          expect(payload, equals(null));
+          c.complete();
+        });
 
-      _action.listen((String payload) {
-        expect(payload, equals(null));
-        c.complete();
-      });
-
-      _action();
+      await _action();
       return c.future;
     });
 
     test('should support dispatch with a payload', () async {
       Completer c = Completer();
-      action.listen((String payload) {
+      action.listen((String? payload) {
         expect(payload, equals('990 guerrero'));
         c.complete();
       });
 
-      action('990 guerrero');
+      await action('990 guerrero');
       return c.future;
     });
 
     test('should dispatch by default when called', () async {
       Completer c = Completer();
-      action.listen((String payload) {
+      action.listen((String? payload) {
         expect(payload, equals('990 guerrero'));
         c.complete();
       });
 
-      action('990 guerrero');
+      await action('990 guerrero');
       return c.future;
     });
 
@@ -74,14 +73,14 @@ void main() {
       test(
           'should invoke and complete synchronous listeners in future event in '
           'event queue', () async {
-        var action = Action();
         var listenerCompleted = false;
-        action.listen((_) {
-          listenerCompleted = true;
-        });
+        var action = Action()
+          ..listen((_) {
+            listenerCompleted = true;
+          });
 
         // No immediate invocation.
-        action();
+        unawaited(action(null));
         expect(listenerCompleted, isFalse);
 
         // Invoked during the next scheduled event in the queue.
@@ -101,7 +100,7 @@ void main() {
         });
 
         // No immediate invocation.
-        action();
+        unawaited(action(null));
         expect(listenerInvoked, isFalse);
 
         // Invoked during next scheduled event in the queue.
@@ -118,12 +117,12 @@ void main() {
         var action = Action();
         var asyncListenerCompleted = false;
         action.listen((_) async {
-          await Future.delayed(Duration(milliseconds: 100), () {
+          await Future.delayed(const Duration(milliseconds: 100), () {
             asyncListenerCompleted = true;
           });
         });
 
-        var future = action();
+        Future<dynamic>? future = action();
         expect(asyncListenerCompleted, isFalse);
 
         await future;
@@ -131,8 +130,7 @@ void main() {
       });
 
       test('should surface errors in listeners', () {
-        var action = Action();
-        action.listen((_) => throw UnimplementedError());
+        var action = Action()..listen((_) => throw UnimplementedError());
         expect(action(0), throwsUnimplementedError);
       });
     });
@@ -186,9 +184,9 @@ void main() {
         const int sampleSize = 1000;
         var stopwatch = Stopwatch();
 
-        var awaitableAction = Action();
-        awaitableAction.listen((_) => {});
-        awaitableAction.listen((_) async {});
+        var awaitableAction = Action()
+          ..listen((_) => {})
+          ..listen((_) async {});
         stopwatch.start();
         for (var i = 0; i < sampleSize; i++) {
           await awaitableAction();
@@ -199,18 +197,233 @@ void main() {
 
         stopwatch.reset();
 
-        Completer syncCompleter;
-        Completer asyncCompleter;
-        var action = Action();
-        action.listen((_) => syncCompleter.complete());
-        action.listen((_) async {
-          asyncCompleter.complete();
-        });
+        late Completer syncCompleter;
+        late Completer asyncCompleter;
+        var action = Action()
+          ..listen((_) => syncCompleter.complete())
+          ..listen((_) async {
+            asyncCompleter.complete();
+          });
         stopwatch.start();
         for (var i = 0; i < sampleSize; i++) {
           syncCompleter = Completer();
           asyncCompleter = Completer();
-          action();
+          await action();
+          await Future.wait([syncCompleter.future, asyncCompleter.future]);
+        }
+        stopwatch.stop();
+        var averageStreamDispatchTime =
+            stopwatch.elapsedMicroseconds / sampleSize / 1000.0;
+
+        print('awaitable action (ms): $averageActionDispatchTime; '
+            'stream-based action (ms): $averageStreamDispatchTime');
+      }, skip: true);
+    });
+  });
+
+  group('Action2', () {
+    late Action2<String> action;
+
+    setUp(() {
+      action = Action2<String>();
+    });
+
+    test('should only be equivalent to itself', () {
+      Action2 _action = Action2();
+      Action2 _action2 = Action2();
+      expect(_action == _action, isTrue);
+      expect(_action == _action2, isFalse);
+    });
+
+    test('should support dispatch with a payload', () async {
+      Completer c = Completer();
+      action.listen((payload) {
+        expect(payload, equals('990 guerrero'));
+        c.complete();
+      });
+
+      await action('990 guerrero');
+      return c.future;
+    });
+
+    test('should dispatch by default when called', () async {
+      Completer c = Completer();
+      action.listen((payload) {
+        expect(payload, equals('990 guerrero'));
+        c.complete();
+      });
+
+      await action('990 guerrero');
+      return c.future;
+    });
+
+    group('dispatch', () {
+      test(
+          'should invoke and complete synchronous listeners in future event in '
+          'event queue', () async {
+        var listenerCompleted = false;
+        action.listen((_) {
+          listenerCompleted = true;
+        });
+
+        // No immediate invocation.
+        unawaited(action('payload'));
+        expect(listenerCompleted, isFalse);
+
+        // Invoked during the next scheduled event in the queue.
+        await Future(() => {});
+        expect(listenerCompleted, isTrue);
+      });
+
+      test(
+          'should invoke asynchronous listeners in future event and complete '
+          'in another future event', () async {
+        var listenerInvoked = false;
+        var listenerCompleted = false;
+        action.listen((_) async {
+          listenerInvoked = true;
+          await Future(() => listenerCompleted = true);
+        });
+
+        // No immediate invocation.
+        unawaited(action('payload'));
+        expect(listenerInvoked, isFalse);
+
+        // Invoked during next scheduled event in the queue.
+        await Future(() => {});
+        expect(listenerInvoked, isTrue);
+        expect(listenerCompleted, isFalse);
+
+        // Completed in next next scheduled event.
+        await Future(() => {});
+        expect(listenerCompleted, isTrue);
+      });
+
+      test('should complete future after listeners complete', () async {
+        var asyncListenerCompleted = false;
+        action.listen((_) async {
+          await Future.delayed(const Duration(milliseconds: 100), () {
+            asyncListenerCompleted = true;
+          });
+        });
+
+        Future<dynamic>? future = action('payload');
+        expect(asyncListenerCompleted, isFalse);
+
+        await future;
+        expect(asyncListenerCompleted, isTrue);
+      });
+
+      test('should surface errors in listeners', () {
+        var actionWithError = action..listen((_) => throw UnimplementedError());
+        expect(actionWithError('payload'), throwsUnimplementedError);
+      });
+    });
+
+    group('listen', () {
+      test('should stop listening when subscription is canceled', () async {
+        var listened = false;
+        var subscription = action.listen((_) => listened = true);
+
+        await action('payload');
+        expect(listened, isTrue);
+
+        listened = false;
+        subscription.cancel();
+        await action('payload');
+        expect(listened, isFalse);
+      });
+
+      test('should stop listening when listeners are cleared', () async {
+        var listened = false;
+        action.listen((_) => listened = true);
+
+        await action('payload');
+        expect(listened, isTrue);
+
+        listened = false;
+        await action.dispose();
+        await action('payload');
+        expect(listened, isFalse);
+      });
+
+      test('should stop listening when actions are disposed', () async {
+        var listened = false;
+        action.listen((_) => listened = true);
+
+        await action('payload');
+        expect(listened, isTrue);
+
+        listened = false;
+        await action.dispose();
+        await action('payload');
+        expect(listened, isFalse);
+      });
+    });
+
+    group('Null typed', () {
+      late Action2<Null> nullAction;
+
+      setUp(() {
+        nullAction = Action2<Null>();
+      });
+
+      test('should support dispatch with a null payload', () async {
+        Completer c = Completer();
+        nullAction.listen((payload) {
+          expect(payload, isNull);
+          c.complete();
+        });
+
+        await nullAction(null);
+        return c.future;
+      });
+    });
+
+    group('void typed', () {
+      var voidAction = Action2<void>();
+
+      test('should support dispatch with a null payload', () async {
+        Completer c = Completer();
+        voidAction.listen((_) {
+          c.complete();
+        });
+
+        await voidAction(null);
+        return c.future;
+      });
+    });
+
+    group('benchmarks', () {
+      test('should dispatch actions faster than streams :(', () async {
+        const int sampleSize = 1000;
+        var stopwatch = Stopwatch();
+
+        var awaitableAction = Action2()
+          ..listen((_) => {})
+          ..listen((_) async {});
+        stopwatch.start();
+        for (var i = 0; i < sampleSize; i++) {
+          await awaitableAction(null);
+        }
+        stopwatch.stop();
+        var averageActionDispatchTime =
+            stopwatch.elapsedMicroseconds / sampleSize / 1000.0;
+
+        stopwatch.reset();
+
+        late Completer syncCompleter;
+        late Completer asyncCompleter;
+        var action = Action2()
+          ..listen((_) => syncCompleter.complete())
+          ..listen((_) async {
+            asyncCompleter.complete();
+          });
+        stopwatch.start();
+        for (var i = 0; i < sampleSize; i++) {
+          syncCompleter = Completer();
+          asyncCompleter = Completer();
+          await action(null);
           await Future.wait([syncCompleter.future, asyncCompleter.future]);
         }
         stopwatch.stop();


### PR DESCRIPTION
## Motivation
Adding APIs in major versions introduces risk, since consumers with opened ranges could accidentally consume new APIs. So instead of exposing Action2 in w_flux 3.0, we will backpatch Action2 to a w_flux 2.x minor, so that it won't be an API addition in w_flux 3.0. This option enables us to start work on the Action migration before the w_flux major release has finished rolling out

## Changes
Add Action2 and appropriate test coverage without null safety work.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_flux/blob/master/CONTRIBUTING.md#manual-testing-criteria
