### PR TITLE
w_flux Migration: Action class to ActionV2

### DIFF
--- a/example/web/random_color/random_color.dart
+++ b/example/web/random_color/random_color.dart
@@ -35,7 +35,7 @@ main() async {
 }
 
 class RandomColorActions {
-  final Action changeBackgroundColor = Action();
+  final ActionV2 changeBackgroundColor = ActionV2();
 }
 
 class RandomColorStore extends Store {
@@ -73,7 +73,7 @@ class _RandomColorComponent
       'This module uses a flux pattern to change its background color.',
       react.button({
         'style': {'padding': '10px', 'margin': '10px'},
-        'onClick': (_) => actions.changeBackgroundColor()
+        'onClick': (_) => actions.changeBackgroundColor(null)
       }, 'Change Background Color')
     ]);
   }

--- a/example/web/todo_app/actions.dart
+++ b/example/web/todo_app/actions.dart
@@ -19,8 +19,8 @@ import 'package:w_flux/w_flux.dart';
 import 'store.dart';
 
 class ToDoActions {
-  final Action<Todo> createTodo = Action<Todo>();
-  final Action<Todo> completeTodo = Action<Todo>();
-  final Action<Todo> deleteTodo = Action<Todo>();
-  final Action clearTodoList = Action<Todo>();
+  final ActionV2<Todo> createTodo = ActionV2<Todo>();
+  final ActionV2<Todo> completeTodo = ActionV2<Todo>();
+  final ActionV2<Todo> deleteTodo = ActionV2<Todo>();
+  final ActionV2 clearTodoList = ActionV2<Todo>();
 }

--- a/example/web/todo_app/components/todo_app_component.dart
+++ b/example/web/todo_app/components/todo_app_component.dart
@@ -48,7 +48,7 @@ class _ToDoAppComponent extends FluxComponent<ToDoActions, ToDoStore> {
   }
 
   _clearList(_) {
-    this.actions.clearTodoList();
+    this.actions.clearTodoList(null);
   }
 
   _createTodo(String value) {

--- a/test/action_test.dart
+++ b/test/action_test.dart
@@ -22,27 +22,27 @@ import 'package:test/test.dart';
 
 void main() {
   group('Action', () {
-    late Action<String> action;
+    late ActionV2<String> action;
 
     setUp(() {
-      action = Action<String>();
+      action = ActionV2<String>();
       addTearDown(action.dispose);
     });
 
     test('should only be equivalent to itself', () {
-      Action action = Action();
-      Action actionV2 = Action();
+      ActionV2 action = ActionV2();
+      ActionV2 actionV2 = ActionV2();
       expect(action == action, isTrue);
       expect(action == actionV2, isFalse);
     });
 
     test('should support dispatch without a payload', () async {
-      Action<String> action = Action<String>()
+      ActionV2<String> action = ActionV2<String>()
         ..listen(expectAsync1((payload) {
           expect(payload, isNull);
         }));
 
-      await action();
+      await action(null);
     });
 
     test('should support dispatch by default when called with a payload',
@@ -59,7 +59,7 @@ void main() {
           'should invoke and complete synchronous listeners in future event in '
           'event queue', () async {
         var listenerCompleted = false;
-        var action = Action()
+        var action = ActionV2()
           ..listen((_) {
             listenerCompleted = true;
           });
@@ -76,7 +76,7 @@ void main() {
       test(
           'should invoke asynchronous listeners in future event and complete '
           'in another future event', () async {
-        var action = Action();
+        var action = ActionV2();
         var listenerInvoked = false;
         var listenerCompleted = false;
         action.listen((_) async {
@@ -99,7 +99,7 @@ void main() {
       });
 
       test('should complete future after listeners complete', () async {
-        var action = Action();
+        var action = ActionV2();
         var asyncListenerCompleted = false;
         action.listen((_) async {
           await Future.delayed(Duration(milliseconds: 100), () {
@@ -107,7 +107,7 @@ void main() {
           });
         });
 
-        Future<dynamic>? future = action();
+        Future<dynamic>? future = action(null);
         expect(asyncListenerCompleted, isFalse);
 
         await future;
@@ -115,51 +115,51 @@ void main() {
       });
 
       test('should surface errors in listeners', () {
-        var action = Action()..listen((_) => throw UnimplementedError());
+        var action = ActionV2()..listen((_) => throw UnimplementedError());
         expect(action(0), throwsUnimplementedError);
       });
     });
 
     group('listen', () {
       test('should stop listening when subscription is canceled', () async {
-        var action = Action();
+        var action = ActionV2();
         var listened = false;
         var subscription = action.listen((_) => listened = true);
 
-        await action();
+        await action(null);
         expect(listened, isTrue);
 
         listened = false;
         subscription.cancel();
-        await action();
+        await action(null);
         expect(listened, isFalse);
       });
 
       test('should stop listening when listeners are cleared', () async {
-        var action = Action();
+        var action = ActionV2();
         var listened = false;
         action.listen((_) => listened = true);
 
-        await action();
+        await action(null);
         expect(listened, isTrue);
 
         listened = false;
         await action.dispose();
-        await action();
+        await action(null);
         expect(listened, isFalse);
       });
 
       test('should stop listening when actions are disposed', () async {
-        var action = Action();
+        var action = ActionV2();
         var listened = false;
         action.listen((_) => listened = true);
 
-        await action();
+        await action(null);
         expect(listened, isTrue);
 
         listened = false;
         await action.dispose();
-        await action();
+        await action(null);
         expect(listened, isFalse);
       });
     });
@@ -169,12 +169,12 @@ void main() {
         const int sampleSize = 1000;
         var stopwatch = Stopwatch();
 
-        var awaitableAction = Action()
+        var awaitableAction = ActionV2()
           ..listen((_) => {})
           ..listen((_) async {});
         stopwatch.start();
         for (var i = 0; i < sampleSize; i++) {
-          await awaitableAction();
+          await awaitableAction(null);
         }
         stopwatch.stop();
         var averageActionDispatchTime =
@@ -184,7 +184,7 @@ void main() {
 
         late Completer syncCompleter;
         late Completer asyncCompleter;
-        var action = Action()
+        var action = ActionV2()
           ..listen((_) => syncCompleter.complete())
           ..listen((_) async {
             asyncCompleter.complete();
@@ -193,7 +193,7 @@ void main() {
         for (var i = 0; i < sampleSize; i++) {
           syncCompleter = Completer();
           asyncCompleter = Completer();
-          await action();
+          await action(null);
           await Future.wait([syncCompleter.future, asyncCompleter.future]);
         }
         stopwatch.stop();

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -94,10 +94,10 @@ void main() {
     });
 
     test('should trigger in response to an action', () async {
-      Action _action = Action();
+      ActionV2 _action = ActionV2();
       store.triggerOnActionV2(_action);
 
-      _action();
+      _action(null);
       Store payload = await store.first;
 
       expect(payload, store);
@@ -106,7 +106,7 @@ void main() {
     test(
         'should execute a given method and then trigger in response to an action',
         () {
-      Action _action = Action();
+      ActionV2 _action = ActionV2();
       bool methodCalled = false;
       syncCallback(_) {
         methodCalled = true;
@@ -117,13 +117,13 @@ void main() {
         expect(payload, store);
         expect(methodCalled, isTrue);
       }) as StoreHandler);
-      _action();
+      _action(null);
     });
 
     test(
         'should execute a given async method and then trigger in response to an action',
         () {
-      Action _action = Action();
+      ActionV2 _action = ActionV2();
       bool afterTimer = false;
       asyncCallback(_) async {
         await Future.delayed(Duration(milliseconds: 30));
@@ -135,13 +135,13 @@ void main() {
         expect(payload, store);
         expect(afterTimer, isTrue);
       }) as StoreHandler);
-      _action();
+      _action(null);
     });
 
     test(
         'should execute a given method and then trigger in response to an action with payload',
         () {
-      Action<num> _action = Action<num>();
+      ActionV2<num> _action = ActionV2<num>();
       num? counter = 0;
       store.triggerOnActionV2(_action, (num? payload) => counter = payload);
       store.listen(expectAsync1((payload) {
@@ -172,7 +172,7 @@ void main() {
     test('cleans up its ActionSubscriptions on dispose', () {
       bool afterDispose = false;
 
-      Action _action = Action();
+      ActionV2 _action = ActionV2();
       store.triggerOnActionV2(_action);
       store.listen(expectAsync1((payload) async {
         // Safety check to avoid infinite trigger loop
@@ -183,15 +183,15 @@ void main() {
         afterDispose = true;
 
         // This should no longer fire after dispose
-        _action();
+        _action(null);
       }) as StoreHandler);
 
-      _action();
+      _action(null);
     });
 
     test('does not allow adding action subscriptions after dispose', () async {
       await store.dispose();
-      expect(() => store.triggerOnActionV2(Action()), throwsStateError);
+      expect(() => store.triggerOnActionV2(ActionV2()), throwsStateError);
     });
 
     test('does not allow listening after dispose', () async {


### PR DESCRIPTION
Runs a codemod to convert w_flux Action to ActionV2. This is being done in preparation for null-safety.
More information can be found in the `w_flux_codemod` [README.md](https://github.com/Workiva/w_flux/blob/master/w_flux_codemod/README.md).
Contact `#support-frontend-dx` slack channel with any additional questions.

[_Created by Sourcegraph batch change `Workiva/w_flux_action_migration`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_flux_action_migration)