### PR TITLE
TEST: Running tests on React 18

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 environment:
     sdk: '>=2.19.0 <3.0.0'
 dependencies:
-  w_flux: 
+  w_flux:
 
 dev_dependencies:
   react: ^7.0.0
@@ -22,13 +22,13 @@ dependency_overrides:
     path: ../
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
   dart_dev_workiva:
     git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
+      url: git@github.com:Workiva/dart_dev_workiva.git
       ref: override-react-js-files-for-r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,3 +20,15 @@ dev_dependencies:
 dependency_overrides:
   w_flux:
     path: ../
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,7 +28,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: git@github.com:Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,5 +22,9 @@ dependency_overrides:
     path: ../
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,18 +19,18 @@ dev_dependencies:
   dart_dev: ^4.0.0
   dependency_validator: ^3.0.0
   test: ^1.18.2
-  workiva_analysis_options: ^1.4.1 
+  workiva_analysis_options: ^1.4.1
 
 dependency_overrides:
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
   dart_dev_workiva:
     git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
+      url: git@github.com:Workiva/dart_dev_workiva.git
       ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: git@github.com:Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,3 +20,17 @@ dev_dependencies:
   dependency_validator: ^3.0.0
   test: ^1.18.2
   workiva_analysis_options: ^1.4.1 
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,5 +24,9 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18

--- a/w_flux_codemod/pubspec.yaml
+++ b/w_flux_codemod/pubspec.yaml
@@ -26,5 +26,9 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18

--- a/w_flux_codemod/pubspec.yaml
+++ b/w_flux_codemod/pubspec.yaml
@@ -28,7 +28,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
-  react_testing_library:
-    git:
-      url: git@github.com:Workiva/react_testing_library.git
-      ref: r18

--- a/w_flux_codemod/pubspec.yaml
+++ b/w_flux_codemod/pubspec.yaml
@@ -32,7 +32,3 @@ dependency_overrides:
     git:
       url: git@github.com:Workiva/react_testing_library.git
       ref: r18
-  dart_dev_workiva:
-    git:
-      url: git@github.com:Workiva/dart_dev_workiva.git
-      ref: override-react-js-files-for-r18

--- a/w_flux_codemod/pubspec.yaml
+++ b/w_flux_codemod/pubspec.yaml
@@ -22,3 +22,17 @@ dev_dependencies:
   meta: ^1.16.0
   source_span: ^1.10.0
   test: ^1.24.3
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/w_flux_codemod/pubspec.yaml
+++ b/w_flux_codemod/pubspec.yaml
@@ -26,13 +26,13 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
   dart_dev_workiva:
     git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
+      url: git@github.com:Workiva/dart_dev_workiva.git
       ref: override-react-js-files-for-r18


### PR DESCRIPTION
DO NOT MERGE. No action needed. This PR adds dependency overrides to https://github.com/Workiva/react-dart/pull/416
in order to test all consumers before rolling out React 18 in all repos.
For more info, see [our Wiki page with the rollout plan](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) and reach out to `#support-ui-platform` on Slack with any questions.

[_Created by Sourcegraph batch change `Workiva/react_18_test`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test)