### PR TITLE
Rollout React 18 to tests and example apps

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   w_flux: 
 
 dev_dependencies:
-  react: ^7.0.0
+  react: ^7.3.0
   build_runner: ^2.0.0
   build_web_compilers: '>=3.0.0 <5.0.0'
   dart_dev: ^4.0.0

--- a/example/web/random_color/index.html
+++ b/example/web/random_color/index.html
@@ -23,7 +23,7 @@ limitations under the License.
     <body>
         <div id="content-container"></div>
 
-        <script src="packages/react/react_with_react_dom_prod.js"></script>
+        <script src="packages/react/js/react.min.js"></script>
         <script defer src="random_color.dart.js"></script>
         
     </body>

--- a/example/web/todo_app/index.html
+++ b/example/web/todo_app/index.html
@@ -24,7 +24,7 @@ limitations under the License.
     <body>
         <div id="content-container"></div>
 
-        <script src="packages/react/react_with_react_dom_prod.js"></script>
+        <script src="packages/react/js/react.min.js"></script>
         <script defer src="todo_app.dart.js"></script>
         
     </body>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   meta: ^1.16.0
-  react: ^7.0.0
+  react: ^7.3.0
   w_common: ^3.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR updates all references to React JS files from the React 17 to [React 18 versions](https://github.com/Workiva/react-dart?tab=readme-ov-file#react-18) which will cause most tests and example apps to run on React 18.

This is Step 2 in our [React 18 migration plan](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=405122049&spaceKey=FEF&title=React%2B18%2BUpgrade#tab-Step+2): `opt most of CI and example apps into React 18, finalize manual testing`.

**Note**: Prod will still be running on React 17 until we roll out React 18 in LaunchDarkly so there will be a period of time after this PR merges
that tests will run on React 18 while prod is still on React 17. This should not cause issues and we will try to keep this period of time as short as possible. Please reach out to `#support-ui-platform` with any questions!

We request that repo owners perform the QA instructions and review/merge these PRs as soon as CI passes. Thank you!

## QA Instructions

- [ ] Verify that updates in this PR affect only tests or example/dev apps, and not HTML files deployed to end-users
- [ ] Passing CI
- [ ] Passing CI on [React 18 Test batch PR](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test) in this repo
- [ ] Manually QA and smoke test your app on React 18 - either by using the `?ld.fews-enable-react-18-in-dart=true` LD flag or by serving the [React 18 test batch PR](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test) locally (see [full instructions on React 18 manual testing here](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade#React18Upgrade-test-in-react-18HowcanItestmyappinReact18?))
  - From our testing, we do not anticipate there being any issues, but would like owning teams to manually smoke test their apps on React 18, focusing on areas of code with more complex components or less test coverage in CI.

For more info, refer to the [React 18 Upgrade wiki page](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) or reach out to `#support-ui-platform` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_18_upgrade`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_upgrade)